### PR TITLE
feat: migrate Claude Code installation from npm to native installer

### DIFF
--- a/claude-terminal/CHANGELOG.md
+++ b/claude-terminal/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 2.0.6
+
+### 🛠️ Improvement - Native Claude Code Installation
+- **Migrated to native installer**: Claude Code now installed using Anthropic's recommended native binary installer
+  - Replaces npm installation (`@anthropic-ai/claude-code`) with `curl -fsSL https://claude.ai/install.sh | bash`
+  - More reliable builds (no npm retry logic needed)
+  - Follows Anthropic's official distribution method
+  - npm installation is deprecated by Anthropic
+- **Updated health checks**: Network connectivity now validates `claude.ai` instead of npm registry
+- **Simplified run.sh**: Removed `node $(which claude)` wrapper, now calls `claude` directly
+
 ## 2.0.5
 
 ### 🐛 Bug Fix - Claude CLI Not Found

--- a/claude-terminal/Dockerfile
+++ b/claude-terminal/Dockerfile
@@ -2,7 +2,7 @@ ARG BUILD_FROM
 FROM ${BUILD_FROM}
 
 # Install packages in a single layer to minimize image size
-# Add retry logic for npm installation to handle network issues
+# Node.js and npm kept for image-service dependency
 RUN apk add --no-cache \
     nodejs \
     npm \
@@ -20,20 +20,12 @@ RUN apk add --no-cache \
     git \
     vim \
     wget \
-    tree \
-    && (npm config set registry https://registry.npmjs.org/ || true) \
-    && (npm config set fetch-retries 3 || true) \
-    && (npm config set fetch-retry-mintimeout 20000 || true) \
-    && (npm config set fetch-retry-maxtimeout 120000 || true) \
-    && (npm config set fetch-timeout 300000 || true) \
-    && for i in 1 2 3; do \
-        echo "Attempt $i: Installing Claude Code CLI..." && \
-        npm install -g @anthropic-ai/claude-code@latest && \
-        echo "Successfully installed Claude Code CLI" && \
-        break || \
-        (echo "Attempt $i failed, retrying in 10 seconds..." && sleep 10); \
-    done \
-    && npm cache clean --force
+    tree
+
+# Install Claude Code CLI using native installer (recommended by Anthropic)
+# Creates symlink to /usr/local/bin for script compatibility
+RUN curl -fsSL https://claude.ai/install.sh | bash \
+    && ln -sf /root/.local/bin/claude /usr/local/bin/claude
 
 # Install Home Assistant CLI (ha command)
 # Download appropriate binary based on build architecture

--- a/claude-terminal/config.yaml
+++ b/claude-terminal/config.yaml
@@ -1,7 +1,7 @@
 ---
 name: "Claude Terminal Pro"
 description: "Enhanced terminal interface for Anthropic's Claude Code CLI with persistent auth, package management, and image paste support. Fork of heytcass/home-assistant-addons"
-version: "2.0.5"
+version: "2.0.6"
 slug: "claude_terminal_pro"
 init: false
 

--- a/claude-terminal/run.sh
+++ b/claude-terminal/run.sh
@@ -257,7 +257,7 @@ get_claude_launch_command() {
 
     if [ "$auto_launch_claude" = "true" ]; then
         # Original behavior: auto-launch Claude directly
-        echo "clear && echo 'Welcome to Claude Terminal!' && echo '' && echo 'Starting Claude...' && sleep 1 && node \$(which claude) ${claude_flags}"
+        echo "clear && echo 'Welcome to Claude Terminal!' && echo '' && echo 'Starting Claude...' && sleep 1 && claude ${claude_flags}"
     else
         # New behavior: show interactive session picker
         if [ -f /usr/local/bin/claude-session-picker ]; then
@@ -265,7 +265,7 @@ get_claude_launch_command() {
         else
             # Fallback if session picker is missing
             bashio::log.warning "Session picker not found, falling back to auto-launch"
-            echo "clear && echo 'Welcome to Claude Terminal!' && echo '' && echo 'Starting Claude...' && sleep 1 && node \$(which claude)"
+            echo "clear && echo 'Welcome to Claude Terminal!' && echo '' && echo 'Starting Claude...' && sleep 1 && claude"
         fi
     fi
 }

--- a/claude-terminal/scripts/health-check.sh
+++ b/claude-terminal/scripts/health-check.sh
@@ -91,18 +91,18 @@ check_network_connectivity() {
     bashio::log.info "=== Network Connectivity Check ==="
 
     # Check DNS resolution first
-    if host registry.npmjs.org >/dev/null 2>&1 || nslookup registry.npmjs.org >/dev/null 2>&1; then
+    if host claude.ai >/dev/null 2>&1 || nslookup claude.ai >/dev/null 2>&1; then
         bashio::log.info "DNS resolution working ✓"
     else
         bashio::log.error "DNS resolution failing - check network configuration"
         bashio::log.info "Try setting custom DNS servers (e.g., 8.8.8.8, 1.1.1.1)"
     fi
 
-    # Try to reach npm registry
-    if curl -s --head --connect-timeout 10 --max-time 15 https://registry.npmjs.org > /dev/null; then
-        bashio::log.info "Can reach npm registry ✓"
+    # Try to reach Claude installer endpoint
+    if curl -s --head --connect-timeout 10 --max-time 15 https://claude.ai/install.sh > /dev/null; then
+        bashio::log.info "Can reach Claude installer ✓"
     else
-        bashio::log.warning "Cannot reach npm registry - this may affect Claude CLI installation"
+        bashio::log.warning "Cannot reach Claude installer - this may affect Claude CLI installation"
         bashio::log.info "This could be due to:"
         bashio::log.info "  - Network proxy/firewall blocking access"
         bashio::log.info "  - DNS resolution issues"


### PR DESCRIPTION
## Summary
- Migrate from deprecated npm installation (`@anthropic-ai/claude-code`) to Anthropic's recommended native binary installer
- Remove npm retry logic and configuration, simplifying the Dockerfile
- Update scripts to call `claude` directly instead of `node $(which claude)`

## Motivation
Anthropic now recommends the native installer as the official distribution method. The npm package is deprecated.

## Changes
| File | Description |
|------|-------------|
| `Dockerfile` | Replace npm install with `curl -fsSL https://claude.ai/install.sh \| bash` |
| `run.sh` | Remove `node` wrapper from claude invocations |
| `health-check.sh` | Update network checks to validate `claude.ai` instead of npm registry |
| `config.yaml` | Bump version to 2.0.6 |
| `CHANGELOG.md` | Document the migration |

## Test plan
- [x] Docker build succeeds
- [x] `claude --version` returns 2.1.17
- [x] Symlink `/usr/local/bin/claude` resolves correctly
- [x] Session picker menu works
- [x] Interactive shell can launch claude

🤖 Generated with [Claude Code](https://claude.ai/code)