### PR TITLE
fix: resolve native install path mismatch (v2.0.7)

### DIFF
--- a/claude-terminal/CHANGELOG.md
+++ b/claude-terminal/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 2.0.7
+
+### 🐛 Bug Fix - Native Install Path Mismatch
+- **Fixed "installMethod is native, but directory does not exist" error**: Claude binary now available at `$HOME/.local/bin/claude` at runtime
+  - **Root cause**: Native installer places Claude at `/root/.local/bin/claude` during Docker build, but at runtime `HOME=/data/home`, so Claude's self-check looks in `/data/home/.local/bin/claude` which didn't exist
+  - **Solution**: Symlink created from `/data/home/.local/bin/claude` → `/root/.local/bin/claude` on startup
+  - **PATH updated**: Added `/data/home/.local/bin` to PATH in both runtime and profile script
+  - **Result**: Claude native binary resolves correctly regardless of HOME directory change
+
 ## 2.0.6
 
 ### 🛠️ Improvement - Native Claude Code Installation

--- a/claude-terminal/config.yaml
+++ b/claude-terminal/config.yaml
@@ -1,7 +1,7 @@
 ---
 name: "Claude Terminal Pro"
 description: "Enhanced terminal interface for Anthropic's Claude Code CLI with persistent auth, package management, and image paste support. Fork of heytcass/home-assistant-addons"
-version: "2.0.6"
+version: "2.0.7"
 slug: "claude_terminal_pro"
 init: false
 

--- a/claude-terminal/run.sh
+++ b/claude-terminal/run.sh
@@ -31,6 +31,18 @@ init_environment() {
     chmod 755 "$data_home" "$config_dir" "$cache_dir" "$state_dir" "$claude_config_dir" "$gh_config_dir" \
               "$persist_root" "$persist_bin" "$persist_lib" "$persist_python"
 
+    # Ensure Claude native binary is available at $HOME/.local/bin/claude
+    # The native installer places it at /root/.local/bin/claude during Docker build,
+    # but at runtime HOME=/data/home, so Claude's self-check looks in /data/home/.local/bin/
+    local native_bin_dir="$data_home/.local/bin"
+    if [ ! -d "$native_bin_dir" ]; then
+        mkdir -p "$native_bin_dir"
+    fi
+    if [ -f /root/.local/bin/claude ] && [ ! -f "$native_bin_dir/claude" ]; then
+        ln -sf /root/.local/bin/claude "$native_bin_dir/claude"
+        bashio::log.info "  - Claude native binary linked: $native_bin_dir/claude"
+    fi
+
     # Set XDG and application environment variables
     export HOME="$data_home"
     export XDG_CONFIG_HOME="$config_dir"
@@ -56,7 +68,7 @@ init_environment() {
     fi
 
     # Setup persistent package paths (HIGHEST PRIORITY)
-    export PATH="$persist_bin:$persist_python/venv/bin:$PATH"
+    export PATH="$persist_bin:$persist_python/venv/bin:$data_home/.local/bin:$PATH"
     export LD_LIBRARY_PATH="$persist_lib:${LD_LIBRARY_PATH:-}"
     export PKG_CONFIG_PATH="$persist_lib/pkgconfig:${PKG_CONFIG_PATH:-}"
 
@@ -81,8 +93,8 @@ export ANTHROPIC_HOME="/data"
 # GitHub CLI persistent configuration
 export GH_CONFIG_DIR="/data/.config/gh"
 
-# Persistent package paths (HIGHEST PRIORITY)
-export PATH="/data/packages/bin:/data/packages/python/venv/bin:$PATH"
+# Persistent package paths and native Claude binary (HIGHEST PRIORITY)
+export PATH="/data/packages/bin:/data/packages/python/venv/bin:/data/home/.local/bin:$PATH"
 export LD_LIBRARY_PATH="/data/packages/lib:${LD_LIBRARY_PATH:-}"
 export PKG_CONFIG_PATH="/data/packages/lib/pkgconfig:${PKG_CONFIG_PATH:-}"
 


### PR DESCRIPTION
## Summary
- **Fixed "installMethod is native, but directory does not exist" error** that caused disconnections and Claude failing to launch
- The native installer places Claude at `/root/.local/bin/claude` during Docker build, but at runtime `HOME=/data/home`, so Claude's self-check looks in `/data/home/.local/bin/claude` which didn't exist
- Creates a symlink from `/data/home/.local/bin/claude` → `/root/.local/bin/claude` on startup
- Adds `/data/home/.local/bin` to PATH in both runtime and profile script

Closes #3

## Test plan
- [ ] Build the add-on with `podman build`
- [ ] Start the container and verify no "installMethod is native" error appears
- [ ] Verify `ls -la /data/home/.local/bin/claude` shows the symlink
- [ ] Verify `claude --version` works from ttyd terminal
- [ ] Verify Claude sessions remain stable without disconnections

🤖 Generated with [Claude Code](https://claude.com/claude-code)