### PR TITLE
fix: resolve session reconnection, auto-update nag, and image service crash (v2.0.8)

### DIFF
--- a/claude-terminal/CHANGELOG.md
+++ b/claude-terminal/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## 2.0.8
+
+### 🐛 Bug Fix - Image Service Crash on WebSocket Errors (#8)
+- **Fixed `res.status is not a function` crash**: The proxy `onError` handler in `server.js` now checks whether `res` is an Express response (HTTP) or a raw socket (WebSocket) before calling `.status()`
+  - Previously, WebSocket proxy errors crashed the entire image service process
+  - Now gracefully handles both HTTP and WebSocket error scenarios
+
+### 🐛 Bug Fix - Disable Auto-Update Nag Inside Container (#7)
+- **Suppressed Claude CLI update prompts**: Set `DISABLE_AUTOUPDATER=1` in both runtime environment and profile script
+  - Claude Code binary is baked into the container image; updates are delivered via add-on releases
+  - Eliminates the persistent "update available" banner on every session start
+
+### 🐛 Bug Fix - Session Reconnection After Disconnect (#6)
+- **Fixed "Press return to reconnect" not working**: Removed `exec` from session picker launch functions so Claude exiting returns to the menu instead of terminating the process
+  - When Claude CLI exits (via `/exit`, Escape, or crash), the session picker menu now reappears automatically
+  - Bash shell sessions also return to menu on `exit`
+  - Removed aggressive EXIT trap that was killing the session picker prematurely
+- **Added ttyd keepalive and auto-reconnect**: Configured `--ping-interval 30` and client-side reconnect options to prevent WebSocket idle disconnects and automatically recover from network interruptions
+
 ## 2.0.7
 
 ### 🐛 Bug Fix - Native Install Path Mismatch

--- a/claude-terminal/config.yaml
+++ b/claude-terminal/config.yaml
@@ -1,7 +1,7 @@
 ---
 name: "Claude Terminal Pro"
 description: "Enhanced terminal interface for Anthropic's Claude Code CLI with persistent auth, package management, and image paste support. Fork of heytcass/home-assistant-addons"
-version: "2.0.7"
+version: "2.0.8"
 slug: "claude_terminal_pro"
 init: false
 

--- a/claude-terminal/image-service/server.js
+++ b/claude-terminal/image-service/server.js
@@ -106,7 +106,12 @@ app.use('/terminal', createProxyMiddleware({
     },
     onError: (err, req, res) => {
         console.error('Proxy error:', err.message);
-        res.status(502).send('Failed to connect to terminal');
+        // res may be a raw socket (WebSocket) instead of an Express response
+        if (typeof res.status === 'function') {
+            res.status(502).send('Failed to connect to terminal');
+        } else if (typeof res.end === 'function') {
+            res.end();
+        }
     },
     logLevel: 'warn'
 }));

--- a/claude-terminal/scripts/claude-session-picker.sh
+++ b/claude-terminal/scripts/claude-session-picker.sh
@@ -58,21 +58,22 @@ launch_claude_new() {
     local flags=$(get_claude_flags)
     echo "🚀 Starting new Claude session..."
     sleep 1
-    exec /usr/local/bin/claude $flags
+    /usr/local/bin/claude $flags
+    # Returns here when Claude exits, loop in main() shows menu again
 }
 
 launch_claude_continue() {
     local flags=$(get_claude_flags)
     echo "⏩ Continuing most recent conversation..."
     sleep 1
-    exec /usr/local/bin/claude -c $flags
+    /usr/local/bin/claude -c $flags
 }
 
 launch_claude_resume() {
     local flags=$(get_claude_flags)
     echo "📋 Opening conversation list for selection..."
     sleep 1
-    exec /usr/local/bin/claude -r $flags
+    /usr/local/bin/claude -r $flags
 }
 
 launch_claude_custom() {
@@ -93,15 +94,14 @@ launch_claude_custom() {
     else
         echo "🚀 Running: claude $custom_args $base_flags"
         sleep 1
-        # Use eval to properly handle quoted arguments
-        eval "exec /usr/local/bin/claude $custom_args $base_flags"
+        eval "/usr/local/bin/claude $custom_args $base_flags"
     fi
 }
 
 launch_auth_helper() {
     echo "🔐 Starting Claude authentication helper..."
     sleep 1
-    exec /opt/scripts/claude-auth-helper.sh
+    /opt/scripts/claude-auth-helper.sh
 }
 
 launch_github_auth() {
@@ -189,9 +189,10 @@ launch_github_auth() {
 
 launch_bash_shell() {
     echo "🐚 Dropping to bash shell..."
-    echo "Tip: Run 'claude' manually when ready"
+    echo "Tip: Run 'claude' manually, type 'exit' to return to this menu"
     sleep 1
-    exec bash
+    bash
+    # Returns here when user types 'exit', loop in main() shows menu again
 }
 
 exit_session_picker() {
@@ -242,9 +243,6 @@ main() {
         esac
     done
 }
-
-# Handle cleanup on exit
-trap 'exit_session_picker' EXIT INT TERM
 
 # Run main function
 main "$@"


### PR DESCRIPTION
## Summary

Fixes three bugs reported by users, bumps version to **2.0.8**.

- **Image service crash on WebSocket errors (#8)**: The proxy `onError` handler called `res.status(502)` on raw sockets during WebSocket disconnections, crashing the entire image service. Now checks response type before calling Express methods.
- **Auto-update nag inside container (#7)**: Claude CLI tried to self-update on every startup, showing persistent banners. Set `DISABLE_AUTOUPDATER=1` in both runtime env and profile script — updates are delivered via add-on releases.
- **Session reconnection after disconnect (#6)**: Removed `exec` from session picker launch functions so Claude exiting returns to the menu loop instead of killing the ttyd process. Added ttyd `--ping-interval 30` and client-side `enableReconnect` options to prevent WebSocket idle disconnects.

## Issues

Closes #6
Closes #7
Closes #8

## Files changed

| File | Change |
|------|--------|
| `image-service/server.js` | Guard `res.status()` call for WebSocket vs HTTP responses |
| `run.sh` | Add `DISABLE_AUTOUPDATER=1`, ttyd keepalive/reconnect flags, session picker fallback on Claude exit |
| `scripts/claude-session-picker.sh` | Remove `exec` from all launch functions, remove EXIT trap |
| `config.yaml` | Version bump to 2.0.8 |
| `CHANGELOG.md` | Document all three fixes |

## Test plan

- [x] Docker build passes
- [x] Node.js syntax validation (`node --check server.js`)
- [x] Bash syntax validation (`bash -n` on all scripts)
- [x] In-container smoke test: all deps resolve, env vars set, no `exec` in launch functions
- [ ] End-to-end: install on HA, verify session picker loops after Claude exit
- [ ] End-to-end: verify no auto-update banner on session start
- [ ] End-to-end: verify image service survives WebSocket disconnections

🤖 Generated with [Claude Code](https://claude.com/claude-code)