### PR TITLE
fix for proxmox

### DIFF
--- a/claude-terminal/CHANGELOG.md
+++ b/claude-terminal/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 2.0.10
+
+### 🐛 Bug Fix - CPU Compatibility (AVX Not Required)
+- **Reverted to npm installation for CPU compatibility**: Fixed Docker build failure on CPUs without AVX support
+  - **Root cause**: Native installer (v2.0.6+) uses Bun runtime which requires AVX CPU instructions
+  - **Affected hardware**: Older NUCs, Intel Atom/Celeron processors, some virtualized environments (Proxmox, VirtualBox on older hosts)
+  - **Error message**: "CPU lacks AVX support" followed by Bun crash with segmentation fault
+  - **Solution**: Switched back to npm installation (`npm install -g @anthropic-ai/claude-code`) which uses Node.js and works on all CPUs
+  - **Trade-off**: npm installation is deprecated by Anthropic but provides broader hardware compatibility
+  - **Result**: Add-on now builds and runs on CPUs without AVX support
+
 ## 2.0.9
 
 ### 🐛 Bug Fix - First Connection Drop on Terminal Load

--- a/claude-terminal/Dockerfile
+++ b/claude-terminal/Dockerfile
@@ -22,10 +22,12 @@ RUN apk add --no-cache \
     wget \
     tree
 
-# Install Claude Code CLI using native installer (recommended by Anthropic)
-# Creates symlink to /usr/local/bin for script compatibility
-RUN curl -fsSL https://claude.ai/install.sh | bash \
-    && ln -sf /root/.local/bin/claude /usr/local/bin/claude
+# Install Claude Code CLI using npm (for CPU compatibility)
+# Native installer uses Bun which requires AVX CPU instructions
+# Many Home Assistant hosts lack AVX (older NUCs, Atom/Celeron, some VMs)
+# npm installation uses Node.js which works on all CPUs
+# npm automatically creates symlink at /usr/local/bin/claude
+RUN npm install -g @anthropic-ai/claude-code
 
 # Install Home Assistant CLI (ha command)
 # Download appropriate binary based on build architecture

--- a/claude-terminal/config.yaml
+++ b/claude-terminal/config.yaml
@@ -1,7 +1,7 @@
 ---
 name: "Claude Terminal Pro"
 description: "Enhanced terminal interface for Anthropic's Claude Code CLI with persistent auth, package management, and image paste support. Fork of heytcass/home-assistant-addons"
-version: "2.0.9"
+version: "2.0.10"
 slug: "claude_terminal_pro"
 init: false
 


### PR DESCRIPTION
# Changelog

+## 2.0.10

### 🐛 Bug Fix - CPU Compatibility (AVX Not Required)
**Reverted to npm installation for CPU compatibility**: Fixed Docker build failure on CPUs without AVX support
 **Root cause**: Native installer (v2.0.6+) uses Bun runtime which requires AVX CPU instructions
**Affected hardware**: Older NUCs, Intel Atom/Celeron processors, some virtualized environments (Proxmox, VirtualBox on older hosts)
**Error message**: "CPU lacks AVX support" followed by Bun crash with segmentation fault
**Solution**: Switched back to npm installation (`npm install -g @anthropic-ai/claude-code`) which uses Node.js and works on all CPUs
**Trade-off**: npm installation is deprecated by Anthropic but provides broader hardware compatibility
**Result**: Add-on now builds and runs on CPUs without AVX support
