### PR TITLE
fix: npm fallback for CPUs without AVX support (v2.0.10)

### DIFF
--- a/claude-terminal/CHANGELOG.md
+++ b/claude-terminal/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 2.0.10
+
+### 🐛 Bug Fix - CPU Compatibility with AVX Fallback
+- **Native installer with automatic npm fallback**: Fixed Docker build failure on CPUs without AVX support (#5)
+  - **How it works**: Tries native installer first (Bun-based, recommended by Anthropic); if it fails (e.g., CPU lacks AVX), automatically falls back to npm installation
+  - **Affected hardware**: Older NUCs, Intel Atom/Celeron processors, some virtualized environments (Proxmox, VirtualBox on older hosts)
+  - **Modern hardware**: No change — continues using the native installer as before
+  - **Result**: Add-on now builds on all CPUs without sacrificing the recommended install method for capable hardware
+
 ## 2.0.9
 
 ### 🐛 Bug Fix - First Connection Drop on Terminal Load

--- a/claude-terminal/Dockerfile
+++ b/claude-terminal/Dockerfile
@@ -22,10 +22,12 @@ RUN apk add --no-cache \
     wget \
     tree
 
-# Install Claude Code CLI using native installer (recommended by Anthropic)
-# Creates symlink to /usr/local/bin for script compatibility
-RUN curl -fsSL https://claude.ai/install.sh | bash \
-    && ln -sf /root/.local/bin/claude /usr/local/bin/claude
+# Install Claude Code CLI
+# Try native installer first (recommended by Anthropic, uses Bun runtime).
+# Falls back to npm if native install fails (e.g., CPU lacks AVX support).
+RUN (curl -fsSL https://claude.ai/install.sh | bash \
+    && ln -sf /root/.local/bin/claude /usr/local/bin/claude) \
+    || npm install -g @anthropic-ai/claude-code
 
 # Install Home Assistant CLI (ha command)
 # Download appropriate binary based on build architecture

--- a/claude-terminal/config.yaml
+++ b/claude-terminal/config.yaml
@@ -1,7 +1,7 @@
 ---
 name: "Claude Terminal Pro"
 description: "Enhanced terminal interface for Anthropic's Claude Code CLI with persistent auth, package management, and image paste support. Fork of heytcass/home-assistant-addons"
-version: "2.0.9"
+version: "2.0.10"
 slug: "claude_terminal_pro"
 init: false
 


### PR DESCRIPTION
## Summary
- Fixes Docker build failure on CPUs without AVX support (#5)
- Instead of replacing the native installer entirely (as in #13), this uses a **fallback strategy**: try native installer first, fall back to npm only if it fails
- Modern hardware continues using the recommended Bun-based native installer
- Older hardware (Atom, Celeron, some Proxmox VMs) gets a working npm fallback automatically

## Approach

```dockerfile
RUN (curl -fsSL https://claude.ai/install.sh | bash \
    && ln -sf /root/.local/bin/claude /usr/local/bin/claude) \
    || npm install -g @anthropic-ai/claude-code
```

| Scenario | What happens |
|----------|-------------|
| CPU with AVX (modern) | Native installer succeeds, uses Bun (recommended) |
| CPU without AVX (older) | Bun segfaults → `\|\|` triggers npm fallback |

## Why this over #13

PR #13 replaces the native installer entirely with npm. That works but:
- Forces **all** users to npm (deprecated by Anthropic), even those on modern hardware
- Higher risk if Anthropic drops npm support in the future

This approach keeps the best of both worlds with zero extra complexity.

## No changes needed in run.sh

The existing symlink logic in `run.sh:41-44` is already defensive — it checks `if [ -f /root/.local/bin/claude ]` before acting. With npm install, that file doesn't exist, so the block is harmlessly skipped.

## Test plan
- [ ] Build on machine with AVX → native installer should succeed
- [ ] Build on machine without AVX (Proxmox with older CPU) → should fall back to npm
- [ ] Verify `claude --version` works in both scenarios

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)