### PR TITLE
feat: add optional persistent Claude override

### DIFF
--- a/claude-terminal/CHANGELOG.md
+++ b/claude-terminal/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 2.0.11
+
+### ✨ New Feature - Optional Persistent Claude Code Override
+- **Safe-by-default persistent Claude support**: Added optional `use_persistent_claude` mode that lets advanced users run a Claude Code version installed under `/data/npm/`
+  - **Default remains unchanged**: the add-on still uses the Claude version baked into the image unless explicitly enabled
+  - **Official startup-managed symlink**: `/usr/local/bin/claude` now points to the persistent install during startup when present
+  - **No self-modifying menu scripts**: persistent override is handled in `run.sh`, keeping behavior deterministic and easier to support
+- **Optional startup updates**: Added `auto_update_claude_on_start` (default: `false`)
+  - When enabled together with `use_persistent_claude`, the add-on runs `npm install -g @anthropic-ai/claude-code@latest` into `/data/npm/` at startup
+  - If the update fails, startup continues and uses the previously installed persistent version when available
+- **Session picker version visibility**: Interactive menu now shows the active Claude Code version at the top
+
 ## 2.0.10
 
 ### 🐛 Bug Fix - CPU Compatibility with AVX Fallback

--- a/claude-terminal/DOCS.md
+++ b/claude-terminal/DOCS.md
@@ -37,6 +37,17 @@ The add-on offers several configuration options:
 - Configure APK and pip packages to auto-install on startup
 - Packages are stored in `/data/packages` and survive restarts
 
+### Optional Persistent Claude Code
+- **Default**: `use_persistent_claude: false`
+- When enabled, the add-on will look for a Claude Code install in `/data/npm/` and use it instead of the version baked into the image
+- This is intended for advanced users who want a persistent override without changing the default supported behavior
+
+### Optional Startup Updates
+- **Default**: `auto_update_claude_on_start: false`
+- Only relevant if `use_persistent_claude: true`
+- When enabled, the add-on will update Claude Code in `/data/npm/` on each startup
+- Safer default is to keep this off and update manually only when needed
+
 **Example Configuration**:
 ```yaml
 auto_launch_claude: false
@@ -46,9 +57,19 @@ persistent_apk_packages:
   - git
 persistent_pip_packages:
   - requests
+use_persistent_claude: true
+auto_update_claude_on_start: false
 ```
 
 Your OAuth credentials are stored in the `/config/claude-config` directory and will persist across add-on updates and restarts, so you won't need to log in again.
+
+If you enable `use_persistent_claude`, install the persistent Claude Code version once from a shell inside the add-on:
+
+```bash
+NPM_CONFIG_PREFIX=/data/npm npm install -g @anthropic-ai/claude-code@latest --prefer-online
+```
+
+After that, restarts will continue using the persistent version automatically.
 
 ## Usage
 

--- a/claude-terminal/README.md
+++ b/claude-terminal/README.md
@@ -37,6 +37,7 @@ This add-on provides a web-based terminal interface with Claude Code CLI pre-ins
 - **Python Virtual Environment**: Isolated Python environment in `/data/packages`
 - **Simple Commands**: Use `persist-install` for easy package management
 - **Persistent Storage**: All packages stored in `/data` which survives all reboots
+- **Optional Persistent Claude Override**: Advanced users can opt into a Claude Code install stored in `/data/npm`
 
 ## Quick Start
 
@@ -72,11 +73,12 @@ claude-logout
 
 ## Configuration
 
-The add-on requires no configuration. All settings are handled automatically:
+The add-on works out of the box, but also supports a few optional advanced settings:
 
 - **Port**: Web interface runs on port 7681
 - **Authentication**: OAuth with Anthropic (credentials stored securely in `/config/claude-config/`)
 - **Terminal**: Full bash environment with Claude Code CLI pre-installed
+- **Persistent Claude override**: Optional `use_persistent_claude` / `auto_update_claude_on_start`
 - **Volumes**: Access to both `/config` (Home Assistant) and `/addons` (for development)
 
 ## Troubleshooting

--- a/claude-terminal/config.yaml
+++ b/claude-terminal/config.yaml
@@ -1,7 +1,7 @@
 ---
 name: "Claude Terminal Pro"
 description: "Enhanced terminal interface for Anthropic's Claude Code CLI with persistent auth, package management, and image paste support. Fork of heytcass/home-assistant-addons"
-version: "2.0.10"
+version: "2.0.11"
 slug: "claude_terminal_pro"
 init: false
 
@@ -35,6 +35,8 @@ options:
   dangerously_skip_permissions: false
   persistent_apk_packages: []
   persistent_pip_packages: []
+  use_persistent_claude: false
+  auto_update_claude_on_start: false
 
 schema:
   auto_launch_claude: bool?
@@ -43,6 +45,8 @@ schema:
     - str?
   persistent_pip_packages:
     - str?
+  use_persistent_claude: bool?
+  auto_update_claude_on_start: bool?
 
 # Volume mappings for file access
 map:

--- a/claude-terminal/run.sh
+++ b/claude-terminal/run.sh
@@ -190,6 +190,41 @@ install_tools() {
     bashio::log.info "Tools installed successfully"
 }
 
+# Configure optional persistent Claude Code override in /data
+setup_persistent_claude() {
+    local use_persistent_claude
+    local auto_update_claude_on_start
+    local persistent_root="/data/npm"
+    local persistent_cli="$persistent_root/lib/node_modules/@anthropic-ai/claude-code/cli.js"
+
+    use_persistent_claude=$(bashio::config 'use_persistent_claude' 'false')
+    auto_update_claude_on_start=$(bashio::config 'auto_update_claude_on_start' 'false')
+
+    if [ "$use_persistent_claude" != "true" ]; then
+        bashio::log.info "Persistent Claude override: disabled"
+        return 0
+    fi
+
+    mkdir -p "$persistent_root"
+
+    if [ "$auto_update_claude_on_start" = "true" ]; then
+        bashio::log.info "Persistent Claude override: updating Claude Code in /data/npm..."
+        if NPM_CONFIG_PREFIX="$persistent_root" npm install -g @anthropic-ai/claude-code@latest --prefer-online; then
+            bashio::log.info "Persistent Claude override: update completed"
+        else
+            bashio::log.warning "Persistent Claude override: update failed, continuing with existing version if present"
+        fi
+    fi
+
+    if [ -f "$persistent_cli" ]; then
+        ln -sf "$persistent_cli" /usr/local/bin/claude
+        bashio::log.info "Persistent Claude override active: /usr/local/bin/claude -> $persistent_cli"
+    else
+        bashio::log.warning "Persistent Claude override enabled but no persistent Claude install found at $persistent_cli"
+        bashio::log.warning "Install it manually once with: NPM_CONFIG_PREFIX=/data/npm npm install -g @anthropic-ai/claude-code@latest"
+    fi
+}
+
 # Setup session picker script
 setup_session_picker() {
     # Copy session picker script from built-in location
@@ -402,6 +437,7 @@ main() {
 
     init_environment
     install_tools
+    setup_persistent_claude
     setup_session_picker
     setup_persistent_packages
     start_web_terminal

--- a/claude-terminal/scripts/claude-session-picker.sh
+++ b/claude-terminal/scripts/claude-session-picker.sh
@@ -25,6 +25,13 @@ show_banner() {
 }
 
 show_menu() {
+    local ver="unknown"
+    if command -v claude &> /dev/null; then
+        ver=$(claude --version 2>/dev/null || echo "unknown")
+    fi
+
+    echo "Claude Code version: $ver"
+    echo ""
     echo "Choose your Claude session type:"
     echo ""
     echo "  1) 🆕 New interactive session (default)"


### PR DESCRIPTION
## Summary\n- add optional persistent Claude override using /data/npm\n- keep baked-in Claude as the default safe path\n- add optional startup update flag for advanced users\n- show active Claude version in the session picker\n\n## Why\nCloses #17 with a conservative implementation that avoids self-modifying menu scripts and keeps default behavior unchanged.\n\n## Validation\n- bash syntax check passed for run.sh and claude-session-picker.sh\n- YAML parse check passed for config.yaml\n- runtime behavior kept safe-by-default\n\n## Notes\nI could not run a full container build from this Telegram runtime because elevated Docker access is not available here, so final container validation is expected from CI / GitHub Actions.