### PR TITLE
chore: add build.yaml image version label for 2.0.11

### DIFF
--- a/claude-terminal/build.yaml
+++ b/claude-terminal/build.yaml
@@ -8,3 +8,5 @@ labels:
   org.opencontainers.image.description: "Terminal interface for Anthropic's Claude Code CLI"
   org.opencontainers.image.source: "https://github.com/anthropics/claude-code"
   org.opencontainers.image.licenses: "MIT"
+
+  org.opencontainers.image.version: "2.0.11"


### PR DESCRIPTION
Small follow-up to align build metadata with release 2.0.11.\n\n- add  to \n\nNo runtime logic changes.