### PR TITLE
Bump base to Alpine 3.21 (musl 1.2.5) so Claude Code ≥2.1.181 can run

### DIFF
--- a/claude-terminal/CHANGELOG.md
+++ b/claude-terminal/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 2.0.12
+
+### 🐛 Bug Fix - Claude Code ≥2.1.181 crashes with `statx: symbol not found`
+- **Bumped base image from Alpine 3.19 to Alpine 3.21** (musl 1.2.4 → musl 1.2.5)
+  - Claude Code's native Bun binary began referencing the `statx` libc wrapper at
+    v2.1.181. musl only added this wrapper in 1.2.5 (Alpine 3.20+); Alpine 3.19
+    (musl 1.2.4) does not export it, causing every version ≥2.1.181 to fail at
+    dynamic-link time with `Error relocating … statx: symbol not found` (exit 127).
+  - The host Linux kernel has had the `statx` *syscall* since 4.11; only the
+    userspace musl wrapper was missing.
+  - With musl 1.2.5 present, Claude Code ≥2.1.181 (and the current latest) loads
+    and runs correctly.
+- **Note on AVX2**: The crash was a linker error, **not** a CPU instruction issue.
+  The existing 2.1.179 binary already runs on non-AVX2 hardware (e.g. AMD GX-415).
+
+
 ## 2.0.11
 
 ### ✨ New Feature - Optional Persistent Claude Code Override

--- a/claude-terminal/build.yaml
+++ b/claude-terminal/build.yaml
@@ -1,7 +1,7 @@
 build_from:
-  aarch64: ghcr.io/home-assistant/aarch64-base:3.19
-  amd64: ghcr.io/home-assistant/amd64-base:3.19
-  armv7: ghcr.io/home-assistant/armv7-base:3.19
+  aarch64: ghcr.io/home-assistant/aarch64-base:3.21
+  amd64: ghcr.io/home-assistant/amd64-base:3.21
+  armv7: ghcr.io/home-assistant/armv7-base:3.21
 
 labels:
   org.opencontainers.image.title: "Home Assistant Add-on: Claude Terminal"
@@ -9,4 +9,4 @@ labels:
   org.opencontainers.image.source: "https://github.com/anthropics/claude-code"
   org.opencontainers.image.licenses: "MIT"
 
-  org.opencontainers.image.version: "2.0.11"
+  org.opencontainers.image.version: "2.0.12"

--- a/claude-terminal/config.yaml
+++ b/claude-terminal/config.yaml
@@ -1,7 +1,7 @@
 ---
 name: "Claude Terminal Pro"
 description: "Enhanced terminal interface for Anthropic's Claude Code CLI with persistent auth, package management, and image paste support. Fork of heytcass/home-assistant-addons"
-version: "2.0.11"
+version: "2.0.12"
 slug: "claude_terminal_pro"
 init: false
 


### PR DESCRIPTION
## Problem

Claude Code ≥ **2.1.181** fails to start on this add-on with:

```
Error relocating /tmp/.../bin/claude: statx: symbol not found
exit=127
```

This is a **dynamic-linker failure**, not a CPU issue. Verified on a live install
(AMD GX-415GA, HA OS 6.18, Alpine 3.19):

```sh
export TESTDIR=/tmp/cc-181
NPM_CONFIG_PREFIX="$TESTDIR" npm install -g @anthropic-ai/claude-code@2.1.181
"$TESTDIR/bin/claude" --version; echo "exit=$?"
# → Error relocating …: statx: symbol not found / exit=127
```

## Root cause

Claude Code's native Bun binary began referencing the `statx` libc wrapper at
**v2.1.181** (the tarball size dropped ~18 MB at that build — a Bun toolchain
rebuild). The `statx()` function was added to **musl 1.2.5**; it is absent in
musl 1.2.4.

| Alpine | musl | `statx` exported? |
|--------|------|-------------------|
| 3.19 (current base) | 1.2.4 | ❌ no |
| 3.20 | 1.2.5 | ✅ yes |
| **3.21** | **1.2.5** | **✅ yes** |

The host kernel (≥ 4.11) has the `statx` *syscall* — only the userspace libc
wrapper is missing on Alpine 3.19.

musl 1.2.5 WHATSNEW: *"statx function (linux extension; via syscall and fallback
using fstatat)"*

## Fix

`claude-terminal/build.yaml`: bump all three base images `3.19 → 3.21`.

`claude-terminal/config.yaml`: bump `version` `2.0.11 → 2.0.12` so that
Supervisor-managed installations surface the update automatically.

## Tested

- v2.1.179 continues to run on the same hardware (no regression; musl 1.2.5 is
  backward compatible).
- After the base bump, v2.1.185 (current latest) loads and runs cleanly on musl
  1.2.5 / Alpine 3.21.

## Note on AVX2

An earlier theory (AVX2 CPU requirement) was disproven by the `exit=127`
relocation error — AVX2 SIGILL would be `exit=132`. The 2.1.179 binary already
runs daily on non-AVX2 hardware; AVX2 is not a factor here.
