### PR TITLE
Add remote_control option (#28)

### DIFF
--- a/claude-terminal/DOCS.md
+++ b/claude-terminal/DOCS.md
@@ -26,6 +26,14 @@ The add-on offers several configuration options:
 - When enabled, Claude starts automatically when you open the terminal
 - When disabled, shows an interactive session picker menu
 
+### Remote Control
+- **Default**: `remote_control: false`
+- When enabled, the auto-launched Claude session starts with the `--remote-control` flag, pairing it with [claude.ai/code](https://claude.ai/code) and the Claude mobile app so you can drive the session from your phone, tablet, or another browser without opening the web terminal first (equivalent to running `claude --remote-control`)
+- Only applies while `auto_launch_claude: true`; it has no effect on the interactive session picker
+- Optionally set `remote_control_session_name` to give the session a fixed title in the session list; leave it empty to let Claude auto-generate one
+- **Requires** a claude.ai OAuth login (API keys are not supported) and Claude Code v2.1.51 or later. It is therefore not available on the ARMv7 build, which pins the portable `1.0.128` release
+- See Anthropic's [Remote Control guide](https://code.claude.com/docs/en/remote-control) for details
+
 ### Dangerously Skip Permissions
 - **Default**: `false`
 - When enabled, Claude runs with `--dangerously-skip-permissions` flag
@@ -56,6 +64,8 @@ The add-on offers several configuration options:
 **Example Configuration**:
 ```yaml
 auto_launch_claude: false
+remote_control: false
+remote_control_session_name: ""
 tmux_mouse: false
 dangerously_skip_permissions: true
 persistent_apk_packages:

--- a/claude-terminal/config.yaml
+++ b/claude-terminal/config.yaml
@@ -1,7 +1,7 @@
 ---
 name: "Claude Terminal Pro"
 description: "Enhanced terminal interface for Anthropic's Claude Code CLI with persistent auth, package management, and image paste support. Fork of heytcass/home-assistant-addons"
-version: "2.0.13"
+version: "2.0.14"
 slug: "claude_terminal_pro"
 init: false
 
@@ -32,6 +32,8 @@ ports_description:
 # Add-on configuration options
 options:
   auto_launch_claude: true
+  remote_control: false
+  remote_control_session_name: ""
   tmux_mouse: false
   dangerously_skip_permissions: false
   persistent_apk_packages: []
@@ -41,6 +43,8 @@ options:
 
 schema:
   auto_launch_claude: bool?
+  remote_control: bool?
+  remote_control_session_name: str?
   tmux_mouse: bool?
   dangerously_skip_permissions: bool?
   persistent_apk_packages:

--- a/claude-terminal/run.sh
+++ b/claude-terminal/run.sh
@@ -393,16 +393,39 @@ auto_install_packages() {
 get_claude_launch_command() {
     local auto_launch_claude
     local dangerously_skip_permissions
+    local remote_control
+    local remote_control_session_name
     local claude_flags=""
 
     # Get configuration values
     auto_launch_claude=$(bashio::config 'auto_launch_claude' 'true')
     dangerously_skip_permissions=$(bashio::config 'dangerously_skip_permissions' 'false')
+    remote_control=$(bashio::config 'remote_control' 'false')
+    remote_control_session_name=$(bashio::config 'remote_control_session_name' '')
 
     # Build Claude flags
     if [ "$dangerously_skip_permissions" = "true" ]; then
         claude_flags="--dangerously-skip-permissions"
         bashio::log.warning "Claude will run with --dangerously-skip-permissions (unrestricted file access)"
+    fi
+
+    # Remote Control: start the auto-launched interactive session already paired
+    # with claude.ai/code and the Claude mobile app (same as `claude --remote-control`),
+    # so a phone or browser can drive it without opening the web terminal first.
+    # Only affects the auto-launch path below; the session picker builds its own
+    # commands. Needs a claude.ai OAuth login and Claude Code v2.1.51+, so it does
+    # nothing on the ARMv7 image that pins the portable 1.0.128 release.
+    if [ "$remote_control" = "true" ]; then
+        claude_flags="${claude_flags:+${claude_flags} }--remote-control"
+        if [ -n "$remote_control_session_name" ]; then
+            # printf %q shell-quotes the name so spaces (and any other special
+            # characters) survive the eval in the tmux wrapper as a single argument.
+            claude_flags="${claude_flags} $(printf '%q' "$remote_control_session_name")"
+        fi
+        bashio::log.info "Remote Control enabled: Claude will start with --remote-control"
+        if [ "$auto_launch_claude" != "true" ]; then
+            bashio::log.warning "remote_control is set but has no effect while auto_launch_claude is false"
+        fi
     fi
 
     if [ "$auto_launch_claude" = "true" ]; then


### PR DESCRIPTION
Adds a `remote_control` option that launches Claude with `--remote-control`.
Defaults to off, so nothing changes unless you enable it. 