### PR TITLE
fix: make copying out of the terminal actually work (#30)

### DIFF
--- a/claude-terminal/CHANGELOG.md
+++ b/claude-terminal/CHANGELOG.md
@@ -61,6 +61,13 @@
   bottom rows — where you type — sat behind the keyboard. The page follows
   `visualViewport` instead, which makes ttyd refit to what is actually visible.
 
+- **Typing no longer repeats itself.** Gboard's predictive text drives an IME
+  composing region, and xterm.js re-emits a commit it has already sent
+  (xtermjs/xterm.js#6060, still open), so a typed phrase landed in the prompt
+  several times over. Nothing outside xterm.js can cancel what it sends, so on
+  touch devices the helper textarea asks for a non-composing keyboard instead.
+  The cost is the suggestion strip.
+
 ### 🔧 Technical
 - Header buttons have a fixed height and a separately sized icon. Emoji sit on a
   larger em box than the label text, so each button was taking its height and

--- a/claude-terminal/CHANGELOG.md
+++ b/claude-terminal/CHANGELOG.md
@@ -49,6 +49,13 @@
   a dangling `?`/`&`/`=`, or a link still running at the edge of the rows read all
   mean "widen the search, then say it is cut off" — pasting half a URL fails with
   nothing on screen explaining why.
+- **Swiping scrolls the terminal.** xterm.js 5.5 drops `touchstart`/`touchmove`
+  outright while the application has mouse reporting on, and never turns touch
+  into a mouse report — so on a phone or a touch PC the history could not be
+  scrolled at all. The wheel has its own code path, which is why a mouse always
+  worked. Swipes are now translated into wheel events, so xterm.js encodes them
+  exactly as it would a real wheel. Vertical is claimed only once a full row of
+  movement has built up; pinch-zoom and horizontal panning stay with the browser.
 
 ### 🔧 Technical
 - Header buttons have a fixed height and a separately sized icon. Emoji sit on a
@@ -61,7 +68,7 @@
   points at `📋`. Serving Home Assistant over HTTPS enables it.
 - OSC 52 *read* requests are swallowed instead of answered, so a program running
   in the terminal cannot read the host clipboard.
-- New regression coverage: 60 Node tests for the clipboard bridge
+- New regression coverage: 72 Node tests for the clipboard bridge
   (`tests/test-terminal-clipboard.js`, wired into `tests/run-tests.sh`) plus tmux
   clipboard assertions in `tests/test-production-run.sh`. The link-rebuilding
   fixtures are the literal rows captured from a running terminal.

--- a/claude-terminal/CHANGELOG.md
+++ b/claude-terminal/CHANGELOG.md
@@ -1,5 +1,71 @@
 # Changelog
 
+## 2.1.0
+
+### 🐛 Bug Fix - Copying out of the terminal did nothing (#30)
+- **Mouse selection now really reaches the clipboard.** ttyd 1.7.7 — the newest
+  release, and the one Alpine 3.21 ships — copies a selection with
+  `document.execCommand('copy')`. xterm.js keeps its selection internally and
+  paints it on a canvas, so there is no DOM selection to copy: the call was a
+  no-op, yet ttyd showed its `✂` overlay every time. Selections are now read with
+  `terminal.getSelection()` and written with `navigator.clipboard.writeText()`,
+  falling back to a hidden textarea where that API does not exist.
+- **`/copy` works.** ttyd 1.7.7 loads no clipboard addon, so the OSC 52 sequence
+  Claude Code emits was silently discarded. The add-on now registers its own
+  OSC 52 handler on ttyd's terminal, sharing the same clipboard writer.
+- **tmux forwards OSC 52.** `set -g set-clipboard on` replaces tmux's default
+  `external`, which drops what applications in the pane send, and
+  `set -as terminal-features ',*:clipboard'` makes tmux emit the sequence outwards
+  without depending on `$TERM`'s terminfo carrying `Ms`.
+- **The `✂` overlay is now honest** — it appears only after the clipboard write
+  actually succeeded, instead of on every selection.
+- **No ttyd fork and no frontend rebuild.** ttyd exports its xterm.js instance as
+  `window.term` and is already proxied same-origin at `/terminal/`, so the fix is
+  one vanilla-JS file, `image-service/public/terminal-clipboard.js`. Upgrading ttyd
+  would not have helped: 1.7.7 is the latest release and still has both bugs.
+
+### ✨ New Feature - Copying on a phone
+- **`📋 Copy` button and dialog.** xterm.js registers no touch handlers in its
+  selection service and paints to a canvas, so a finger can select nothing in the
+  terminal at all — on a phone there was no way to copy anything. The button reads
+  the text out of the xterm.js buffer into a textarea, where a long-press gives
+  the native selection handles, with a one-tap "Copy all" and a
+  visible-screen/full-scrollback switch.
+- **`🔗 Copy link` appears by itself when a link is on screen.** Copying an OAuth
+  login URL is one tap, no selecting. It names the host it copied, since a phone
+  has no hover to check with.
+- **Split links are put back together.** A link that the terminal broke across
+  rows used to be copied as whatever fitted on one row. Rebuilding it needs the
+  row geometry, and three different splits were measured live in this add-on's
+  own terminal, each leaving a different trace:
+  - a hard wrap fills the row and re-indents the remainder, so joining rows
+    verbatim drops the indent into the middle of the URL;
+  - Claude Code's renderer breaks a long URL at a `/` when the next segment would
+    not fit, leaving a row that is *not* full;
+  - and it lays its output out one column short of the pane, so any rule keyed on
+    the pane width never fires. The wrap column is now measured from the rows
+    themselves rather than assumed.
+- **A cut-off link is refused, not copied.** Trailing `…`, a cut percent-escape,
+  a dangling `?`/`&`/`=`, or a link still running at the edge of the rows read all
+  mean "widen the search, then say it is cut off" — pasting half a URL fails with
+  nothing on screen explaining why.
+
+### 🔧 Technical
+- Header buttons have a fixed height and a separately sized icon. Emoji sit on a
+  larger em box than the label text, so each button was taking its height and
+  width from its own glyph and the row came out ragged.
+- Plain-HTTP limitation documented in `DOCS.md`: `navigator.clipboard` is a
+  secure-context API, so over `http://homeassistant.local:8123` the fallback needs
+  a user gesture. Every button tap is one; an OSC 52 sequence arriving from the
+  terminal is not, so `/copy` is refused there and the page says so in words and
+  points at `📋`. Serving Home Assistant over HTTPS enables it.
+- OSC 52 *read* requests are swallowed instead of answered, so a program running
+  in the terminal cannot read the host clipboard.
+- New regression coverage: 60 Node tests for the clipboard bridge
+  (`tests/test-terminal-clipboard.js`, wired into `tests/run-tests.sh`) plus tmux
+  clipboard assertions in `tests/test-production-run.sh`. The link-rebuilding
+  fixtures are the literal rows captured from a running terminal.
+
 ## 2.0.13
 
 ### Bug fixes

--- a/claude-terminal/CHANGELOG.md
+++ b/claude-terminal/CHANGELOG.md
@@ -56,6 +56,10 @@
   worked. Swipes are now translated into wheel events, so xterm.js encodes them
   exactly as it would a real wheel. Vertical is claimed only once a full row of
   movement has built up; pinch-zoom and horizontal panning stay with the browser.
+  A swipe is ignored when the buffer has no scrollback: xterm.js turns a wheel
+  event into arrow keys there and sends them as *input*, so under tmux every
+  swipe walked Claude Code's message history into the prompt. Scrolling a
+  full-screen app needs real mouse reporting — turn on the `tmux_mouse` option.
 - **The on-screen keyboard no longer covers the prompt.** It shrinks the visual
   viewport but leaves `100vh` alone, so the terminal kept its full height and its
   bottom rows — where you type — sat behind the keyboard. The page follows

--- a/claude-terminal/CHANGELOG.md
+++ b/claude-terminal/CHANGELOG.md
@@ -65,12 +65,6 @@
   bottom rows — where you type — sat behind the keyboard. The page follows
   `visualViewport` instead, which makes ttyd refit to what is actually visible.
 
-- **Typing no longer repeats itself.** Gboard's predictive text drives an IME
-  composing region, and xterm.js re-emits a commit it has already sent
-  (xtermjs/xterm.js#6060, still open), so a typed phrase landed in the prompt
-  several times over. Nothing outside xterm.js can cancel what it sends, so on
-  touch devices the helper textarea asks for a non-composing keyboard instead.
-  The cost is the suggestion strip.
 
 ### 🔧 Technical
 - Header buttons have a fixed height and a separately sized icon. Emoji sit on a

--- a/claude-terminal/CHANGELOG.md
+++ b/claude-terminal/CHANGELOG.md
@@ -56,6 +56,10 @@
   worked. Swipes are now translated into wheel events, so xterm.js encodes them
   exactly as it would a real wheel. Vertical is claimed only once a full row of
   movement has built up; pinch-zoom and horizontal panning stay with the browser.
+- **The on-screen keyboard no longer covers the prompt.** It shrinks the visual
+  viewport but leaves `100vh` alone, so the terminal kept its full height and its
+  bottom rows — where you type — sat behind the keyboard. The page follows
+  `visualViewport` instead, which makes ttyd refit to what is actually visible.
 
 ### 🔧 Technical
 - Header buttons have a fixed height and a separately sized icon. Emoji sit on a

--- a/claude-terminal/DOCS.md
+++ b/claude-terminal/DOCS.md
@@ -38,6 +38,46 @@ The add-on offers several configuration options:
 - Keep disabled for reliable native browser copy/paste in the ttyd terminal, including OAuth codes
 - Enable only if you prefer tmux mouse selection, scrolling, and pane controls
 
+### Copying Text Out of the Terminal
+
+There are four ways, and which ones you need depends on the device:
+
+- **`🔗 Copy link`** appears in the header on its own whenever a link is on
+  screen. One tap copies it, and the status line names the host it took. This is
+  the quickest way to get an OAuth login URL out, on any device.
+- **`📋 Copy`** opens the terminal's text in a box you can select from. On a
+  phone this is the only way to copy arbitrary text: xterm.js has no touch
+  support in its selection code and draws to a canvas, so a finger cannot select
+  anything in the terminal itself. Long-press in the box for the native selection
+  handles, or use **Copy all**. The switch chooses the visible screen or the
+  whole scrollback.
+- **Mouse selection** copies automatically on a computer. The scissors overlay
+  (`✂`) appears only when the clipboard was actually written.
+- **Claude Code's `/copy`** emits an OSC 52 escape sequence; tmux forwards it
+  (`set-clipboard on`) and the browser writes it to the clipboard.
+
+**Long links.** The terminal breaks a long URL across rows, and the add-on puts
+it back together — including the case where the tail is re-indented, which would
+otherwise leave spaces inside the link. If a link is cut off at the edge of the
+screen it is refused rather than copied in half, and the status line says so;
+scroll until all of it is visible.
+
+**Plain HTTP.** Over `http://homeassistant.local:8123` browsers do not expose
+`navigator.clipboard` at all — that API is restricted to secure contexts. The
+add-on falls back to a hidden-textarea copy, which Chrome only permits while it
+is handling a user gesture:
+
+- Every **button** works, because your tap is the gesture. So does mouse
+  selection, because releasing the button is one.
+- **`/copy` does not.** It arrives from the terminal with no tap behind it, so
+  the browser refuses it; the add-on says so and points at `📋`. Nothing the page
+  can do changes this — it is the browser's security model, not a bug.
+- Serving Home Assistant over HTTPS makes `/copy` work too.
+
+**Reading** the clipboard *from* the terminal is deliberately not implemented:
+OSC 52 read requests (`\e]52;c;?\a`) are swallowed rather than answered, so a
+program in the terminal cannot exfiltrate your clipboard.
+
 ### Persistent Packages
 - Configure APK and pip packages to auto-install on startup
 - Packages are stored in `/data/packages` and survive restarts

--- a/claude-terminal/DOCS.md
+++ b/claude-terminal/DOCS.md
@@ -74,6 +74,18 @@ is handling a user gesture:
   can do changes this — it is the browser's security model, not a bug.
 - Serving Home Assistant over HTTPS makes `/copy` work too.
 
+### Scrolling on a Phone or Touch Screen
+
+Swipe up and down over the terminal. A mouse wheel has always worked, but touch
+did not: xterm.js ignores touch entirely while the program in the terminal has
+taken over the mouse, which Claude Code does. Swipes are now translated into
+wheel events, so they behave the same as a wheel.
+
+Pinch-zoom and horizontal panning still belong to the browser, and putting a
+second finger down stops the scroll — so a pinch is not read as a drag.
+
+### Reading the Clipboard
+
 **Reading** the clipboard *from* the terminal is deliberately not implemented:
 OSC 52 read requests (`\e]52;c;?\a`) are swallowed rather than answered, so a
 program in the terminal cannot exfiltrate your clipboard.

--- a/claude-terminal/build.yaml
+++ b/claude-terminal/build.yaml
@@ -9,4 +9,4 @@ labels:
   org.opencontainers.image.source: "https://github.com/anthropics/claude-code"
   org.opencontainers.image.licenses: "MIT"
 
-  org.opencontainers.image.version: "2.0.13"
+  org.opencontainers.image.version: "2.1.0"

--- a/claude-terminal/config.yaml
+++ b/claude-terminal/config.yaml
@@ -1,7 +1,7 @@
 ---
 name: "Claude Terminal Pro"
 description: "Enhanced terminal interface for Anthropic's Claude Code CLI with persistent auth, package management, and image paste support. Fork of heytcass/home-assistant-addons"
-version: "2.0.13"
+version: "2.1.0"
 slug: "claude_terminal_pro"
 init: false
 

--- a/claude-terminal/image-service/public/index.html
+++ b/claude-terminal/image-service/public/index.html
@@ -2,7 +2,11 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <!-- interactive-widget shrinks the layout viewport when the keyboard opens,
+         so 100vh and the iframe shrink with it. The default, resizes-visual,
+         leaves layout alone and the prompt stays behind the keyboard until
+         something else forces a redraw. -->
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, interactive-widget=resizes-content">
     <title>Claude Terminal Pro</title>
     <style>
         * {
@@ -1024,15 +1028,16 @@
         });
 
         // --- Keep the prompt above the on-screen keyboard ---
-        // The keyboard shrinks the visual viewport but leaves 100vh alone, so
-        // the terminal keeps its full height and its bottom rows - the prompt -
-        // sit behind the keyboard. Track the visual viewport instead; shrinking
-        // the container makes the iframe fire resize, and ttyd refits.
+        // interactive-widget in the viewport meta does this on Chrome. Safari
+        // ignores it, so follow the visual viewport as well; shrinking the
+        // container makes the iframe fire resize and ttyd refits.
 
         function trackOnScreenKeyboard() {
             const viewport = window.visualViewport;
             const container = document.getElementById('container');
             if (!viewport || !container) return;
+
+            let settle;
 
             const apply = () => {
                 // A bogus height would collapse the terminal entirely.
@@ -1040,6 +1045,16 @@
                 container.style.height = viewport.height + 'px';
                 // iOS pans the layout viewport when an input takes focus.
                 window.scrollTo(0, 0);
+
+                // The keyboard animates, so the height arrives in steps. Pin to
+                // the bottom once it stops moving, rather than on every step -
+                // otherwise the view only catches up when something else
+                // redraws, which is why it used to wait for a keystroke.
+                clearTimeout(settle);
+                settle = setTimeout(() => {
+                    const controller = terminalController();
+                    if (controller) controller.scrollToBottom();
+                }, 150);
             };
 
             viewport.addEventListener('resize', apply);

--- a/claude-terminal/image-service/public/index.html
+++ b/claude-terminal/image-service/public/index.html
@@ -41,17 +41,31 @@
             color: #ccc;
         }
 
+        /* One fixed height for every header button. Emoji sit on a larger em
+           box than the label text, so without this each button takes its height
+           from its own icon and the row comes out ragged. */
         .header-btn {
             background: #007acc;
             color: white;
             border: none;
-            padding: 6px 12px;
+            height: 30px;
+            padding: 0 12px;
             border-radius: 4px;
             cursor: pointer;
             font-size: 12px;
-            display: flex;
+            line-height: 1;
+            white-space: nowrap;
+            display: inline-flex;
             align-items: center;
+            justify-content: center;
             gap: 6px;
+        }
+
+        /* The icon span: sized on its own so it cannot stretch the button. */
+        .header-btn > span:first-child {
+            font-size: 14px;
+            line-height: 1;
+            display: block;
         }
 
         .header-btn:hover {
@@ -267,6 +281,155 @@
         #voice-status.listening {
             color: #d9534f;
         }
+
+        /* Copy modal: the only way to copy on a touch device, where xterm.js
+           has no selection at all. */
+        #copy-modal {
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            background: rgba(0, 0, 0, 0.8);
+            display: none;
+            align-items: center;
+            justify-content: center;
+            z-index: 2000;
+        }
+
+        #copy-modal.active {
+            display: flex;
+        }
+
+        #copy-modal-content {
+            background: #2d2d2d;
+            border-radius: 8px;
+            padding: 16px;
+            max-width: 700px;
+            width: 94%;
+            border: 1px solid #3d3d3d;
+        }
+
+        #copy-modal-title {
+            font-size: 16px;
+            font-weight: 500;
+            margin-bottom: 8px;
+            color: #fff;
+        }
+
+        #copy-hint {
+            font-size: 12px;
+            color: #888;
+            margin-bottom: 10px;
+        }
+
+        /* A real textarea, so a long-press gives the native mobile
+           selection handles and the OS copy menu. */
+        #copy-text {
+            width: 100%;
+            height: 45vh;
+            background: #1e1e1e;
+            border: 1px solid #3d3d3d;
+            border-radius: 4px;
+            padding: 10px;
+            color: #ddd;
+            font-family: 'SF Mono', Menlo, Consolas, monospace;
+            font-size: 12px;
+            line-height: 1.45;
+            white-space: pre;
+            overflow: auto;
+            resize: none;
+            -webkit-user-select: text;
+            user-select: text;
+        }
+
+        .copy-options {
+            display: flex;
+            gap: 12px;
+            align-items: center;
+            margin: 10px 0;
+            font-size: 12px;
+            color: #aaa;
+            flex-wrap: wrap;
+        }
+
+        .copy-options label {
+            display: flex;
+            align-items: center;
+            gap: 5px;
+            cursor: pointer;
+        }
+
+        #copy-status {
+            font-size: 12px;
+            color: #888;
+            min-height: 18px;
+            margin-bottom: 8px;
+        }
+
+        #copy-status.success {
+            color: #5cb85c;
+        }
+
+        #copy-status.error {
+            color: #d9534f;
+        }
+
+        /* The link button appears on its own when a URL shows up in the
+           terminal, so copying an OAuth link is one tap and no selecting. */
+        #link-btn {
+            background: #2ea043;
+        }
+
+        #link-btn:hover {
+            background: #268a39;
+        }
+
+        #link-btn.copied {
+            background: #1a7f37;
+        }
+
+        /* Phones: the button labels do not fit next to the title. */
+        @media (max-width: 700px) {
+            #header-title {
+                display: none;
+            }
+
+            #header {
+                justify-content: flex-end;
+            }
+
+            /* Icon-only, so make them square rather than letting the padding
+               decide the width per emoji. */
+            .header-btn {
+                width: 38px;
+                height: 34px;
+                padding: 0;
+            }
+
+            .header-btn > span:first-child {
+                font-size: 16px;
+            }
+
+            .header-btn .btn-label {
+                display: none;
+            }
+
+            .modal-buttons {
+                flex-wrap: wrap;
+            }
+
+            .modal-btn {
+                flex: 1 1 auto;
+                padding: 12px 16px;
+                font-size: 14px;
+            }
+
+            #copy-text {
+                height: 40vh;
+                font-size: 13px;
+            }
+        }
     </style>
 </head>
 <body>
@@ -275,13 +438,21 @@
             <div id="header-title">Claude Terminal Pro - Voice & image support</div>
             <div style="display: flex; align-items: center; gap: 12px;">
                 <span id="status"></span>
+                <button id="link-btn" class="header-btn" title="Copy the link shown in the terminal" style="display: none;">
+                    <span>🔗</span>
+                    <span class="btn-label">Copy link</span>
+                </button>
+                <button id="copy-btn" class="header-btn" title="Copy terminal text">
+                    <span>📋</span>
+                    <span class="btn-label">Copy</span>
+                </button>
                 <button id="voice-btn" class="header-btn">
                     <span>🎤</span>
-                    <span>Voice Input</span>
+                    <span class="btn-label">Voice Input</span>
                 </button>
                 <button id="upload-btn" class="header-btn">
                     <span>📎</span>
-                    <span>Upload Image</span>
+                    <span class="btn-label">Upload Image</span>
                 </button>
             </div>
         </div>
@@ -293,6 +464,31 @@
         </div>
     </div>
     <input type="file" id="file-input" accept="image/*">
+
+    <!-- Copy Modal: touch devices cannot select terminal text at all -->
+    <div id="copy-modal">
+        <div id="copy-modal-content">
+            <div id="copy-modal-title">📋 Copy terminal text</div>
+            <div id="copy-hint">Long-press in the box to select part of it, or use "Copy all".</div>
+            <div id="copy-status"></div>
+            <textarea id="copy-text" readonly spellcheck="false" autocapitalize="off" autocorrect="off"></textarea>
+            <div class="copy-options">
+                <label><input type="radio" name="copy-scope" value="screen" checked> Visible screen</label>
+                <label><input type="radio" name="copy-scope" value="all"> Full scrollback</label>
+                <label id="copy-scope-selection" style="display: none;"><input type="radio" name="copy-scope" value="selection"> Selection</label>
+            </div>
+            <div class="copy-options">
+                <label title="tmux breaks long lines at the pane width; rejoining them keeps URLs in one piece">
+                    <input type="checkbox" id="copy-join" checked> Rejoin wrapped lines
+                </label>
+            </div>
+            <div class="modal-buttons">
+                <button id="copy-url-btn" class="modal-btn modal-btn-primary" style="display: none;">Copy link</button>
+                <button id="copy-all-btn" class="modal-btn modal-btn-primary">Copy all</button>
+                <button id="copy-close-btn" class="modal-btn modal-btn-secondary">Close</button>
+            </div>
+        </div>
+    </div>
 
     <!-- Voice Input Modal -->
     <div id="voice-modal">
@@ -308,6 +504,7 @@
         </div>
     </div>
 
+    <script src="terminal-clipboard.js"></script>
     <script>
         let ttydPort = 7681;
         let uploadDir = '/data/images';
@@ -333,6 +530,31 @@
             const iframe = document.getElementById('terminal-frame');
             // Use relative path for Home Assistant ingress compatibility
             iframe.src = 'terminal/';
+            // ttyd cannot copy an xterm.js selection on its own, and ignores OSC 52
+            installTerminalClipboard(iframe);
+        }
+
+        // Fixes mouse-selection copy and Claude Code's /copy (OSC 52) inside ttyd.
+        let clipboardBridge = null;
+
+        function installTerminalClipboard(iframe) {
+            const bridge = window.ClaudeTerminalClipboard;
+            if (!bridge) {
+                console.warn('terminal-clipboard.js not loaded, terminal copy will not work');
+                return;
+            }
+            clipboardBridge = bridge.attach(iframe, {
+                onError: (err) => console.error('Clipboard bridge failed:', err),
+                onTimeout: () => console.warn('Terminal did not expose window.term, clipboard bridge inactive'),
+                // Only reachable for /copy on a plain-HTTP origin, where the
+                // browser has no clipboard API and refuses the fallback without
+                // a user gesture. Say so and point at a button that has one.
+                onRefused: () => setStatus(
+                    'The browser blocked /copy over plain HTTP — use 📋 instead (or open Home Assistant over HTTPS)',
+                    'error',
+                    true
+                )
+            });
         }
 
         const status = document.getElementById('status');
@@ -674,6 +896,195 @@
             const iframe = document.getElementById('terminal-frame');
             iframe.addEventListener('dragover', (e) => e.preventDefault());
             iframe.addEventListener('drop', (e) => e.preventDefault());
+        });
+
+        // --- Copy terminal text: the only path a touch device has ---
+        // xterm.js has no touch selection and paints to a canvas, so a finger
+        // selects nothing. Read the buffer into a textarea instead, where a
+        // long-press gives the native handles.
+
+        const copyModal = document.getElementById('copy-modal');
+        const copyBtn = document.getElementById('copy-btn');
+        const copyTextArea = document.getElementById('copy-text');
+        const copyStatus = document.getElementById('copy-status');
+        const copyAllBtn = document.getElementById('copy-all-btn');
+        const copyUrlBtn = document.getElementById('copy-url-btn');
+        const copyCloseBtn = document.getElementById('copy-close-btn');
+        const copyScopeSelection = document.getElementById('copy-scope-selection');
+        const copyJoin = document.getElementById('copy-join');
+
+        function currentCopyScope() {
+            const checked = document.querySelector('input[name="copy-scope"]:checked');
+            return checked ? checked.value : 'screen';
+        }
+
+        function setCopyStatus(message, type = '') {
+            copyStatus.textContent = message;
+            copyStatus.className = type;
+        }
+
+        function terminalController() {
+            return clipboardBridge ? clipboardBridge.getController() : null;
+        }
+
+        function refreshCopyText() {
+            const controller = terminalController();
+            if (!controller) {
+                copyTextArea.value = '';
+                setCopyStatus('Terminal is not ready yet.', 'error');
+                return;
+            }
+            copyTextArea.value = controller.read(currentCopyScope(), copyJoin.checked);
+
+            // Ask the terminal, not the textarea: rebuilding a link that was
+            // split across rows needs the row geometry, which the flattened
+            // text no longer has.
+            const found = controller.findLink();
+            copyUrlBtn.style.display = found.url ? 'block' : 'none';
+            copyUrlBtn.dataset.url = found.url || '';
+            if (found.url) {
+                setCopyStatus('Found a link — "Copy link" copies just that.');
+            } else if (found.problem === 'truncated') {
+                setCopyStatus('A link is on screen but cut off — try "Full scrollback".', 'error');
+            } else {
+                setCopyStatus('');
+            }
+        }
+
+        function openCopyModal() {
+            const controller = terminalController();
+            // Only offer the "Selection" scope when there actually is one
+            // (desktop with a mouse); on a phone there never is.
+            const hasSelection = !!(controller && controller.hasSelection());
+            copyScopeSelection.style.display = hasSelection ? 'flex' : 'none';
+            if (hasSelection) {
+                copyScopeSelection.querySelector('input').checked = true;
+            } else if (currentCopyScope() === 'selection') {
+                document.querySelector('input[name="copy-scope"][value="screen"]').checked = true;
+            }
+
+            refreshCopyText();
+            copyModal.classList.add('active');
+        }
+
+        function closeCopyModal() {
+            copyModal.classList.remove('active');
+            setCopyStatus('');
+        }
+
+        copyBtn.addEventListener('click', openCopyModal);
+        copyCloseBtn.addEventListener('click', closeCopyModal);
+        copyModal.addEventListener('click', (e) => {
+            if (e.target === copyModal) closeCopyModal();
+        });
+        document.querySelectorAll('input[name="copy-scope"]').forEach((radio) => {
+            radio.addEventListener('change', refreshCopyText);
+        });
+        copyJoin.addEventListener('change', refreshCopyText);
+
+        copyUrlBtn.addEventListener('click', async () => {
+            const url = copyUrlBtn.dataset.url;
+            if (!url) return;
+
+            if (await copyToClipboard(url)) {
+                setCopyStatus(`✓ Copied the link (${url.length} chars).`, 'success');
+                return;
+            }
+            // Select just the link so the OS copy menu picks it up.
+            const at = copyTextArea.value.indexOf(url);
+            copyTextArea.focus();
+            if (at !== -1) copyTextArea.setSelectionRange(at, at + url.length);
+            setCopyStatus('Could not copy automatically - the link is selected, use your device\'s Copy.', 'error');
+        });
+
+        // The tap on this button is the user gesture that the execCommand
+        // fallback needs, so this works on plain HTTP too.
+        copyAllBtn.addEventListener('click', async () => {
+            const text = copyTextArea.value;
+            if (!text) {
+                setCopyStatus('Nothing to copy.', 'error');
+                return;
+            }
+
+            if (await copyToClipboard(text)) {
+                setCopyStatus(`✓ Copied ${text.split('\n').length} lines.`, 'success');
+                return;
+            }
+
+            // Last resort: hand it to the OS selection UI.
+            copyTextArea.focus();
+            copyTextArea.setSelectionRange(0, text.length);
+            setCopyStatus('Could not copy automatically - the text is selected, use your device\'s Copy.', 'error');
+        });
+
+        document.addEventListener('keydown', (e) => {
+            if (e.key === 'Escape' && copyModal.classList.contains('active')) closeCopyModal();
+        });
+
+        // --- One-tap link copy ---
+        // What people copy is almost always a login URL, and selecting it by
+        // finger is painful even above. Watch for one and offer a button; the
+        // tap is also the gesture the execCommand fallback needs.
+
+        const linkBtn = document.getElementById('link-btn');
+        let pendingLink = null;
+
+        const LINK_PROBLEM_MESSAGE = {
+            none: 'No link on screen',
+            truncated: 'The link on screen is cut off - scroll so all of it is visible',
+            invalid: 'That does not look like a complete link'
+        };
+
+        function scanForLink() {
+            const controller = terminalController();
+            if (!controller) return;
+
+            const url = controller.findLink().url;
+            if (url === pendingLink) return;
+
+            pendingLink = url;
+            linkBtn.style.display = url ? 'inline-flex' : 'none';
+            linkBtn.classList.remove('copied');
+            // Shows the host on hover, so it is obvious what will be copied.
+            linkBtn.title = url ? `Copy ${url}` : 'Copy the link shown in the terminal';
+        }
+
+        setInterval(scanForLink, 1500);
+
+        linkBtn.addEventListener('click', async () => {
+            // Re-check on the tap rather than trusting the 1.5s poll: the
+            // screen may have changed, and a stale truncated link is exactly
+            // the "unfinished http..." that is worse than no link at all.
+            const controller = terminalController();
+            const found = controller ? controller.findLink() : { url: null, problem: 'none' };
+
+            if (!found.url) {
+                pendingLink = null;
+                linkBtn.style.display = 'none';
+                setStatus(LINK_PROBLEM_MESSAGE[found.problem] || LINK_PROBLEM_MESSAGE.none, 'error');
+                return;
+            }
+
+            pendingLink = found.url;
+            if (await copyToClipboard(found.url)) {
+                linkBtn.classList.add('copied');
+                // Name the host: on a phone there is no hover, so this is the
+                // only way to see which link was taken when several are up.
+                let host = found.url;
+                try { host = new URL(found.url).host; } catch (err) { /* keep the raw URL */ }
+                setStatus(`✓ Copied link to ${host} (${found.url.length} chars)`, 'success');
+                return;
+            }
+
+            // Copy was refused: fall back to the dialog, where the link is
+            // preselected for the OS copy menu.
+            setStatus('Could not copy automatically - opening the copy dialog', 'error');
+            openCopyModal();
+            const at = copyTextArea.value.indexOf(found.url);
+            if (at !== -1) {
+                copyTextArea.focus();
+                copyTextArea.setSelectionRange(at, at + found.url.length);
+            }
         });
 
         // ========================================

--- a/claude-terminal/image-service/public/index.html
+++ b/claude-terminal/image-service/public/index.html
@@ -19,6 +19,8 @@
             height: 100vh;
         }
 
+        /* Height is overwritten in px from visualViewport once the on-screen
+           keyboard is up - 100vh ignores it. See trackOnScreenKeyboard(). */
         #container {
             display: flex;
             flex-direction: column;
@@ -1020,6 +1022,32 @@
         document.addEventListener('keydown', (e) => {
             if (e.key === 'Escape' && copyModal.classList.contains('active')) closeCopyModal();
         });
+
+        // --- Keep the prompt above the on-screen keyboard ---
+        // The keyboard shrinks the visual viewport but leaves 100vh alone, so
+        // the terminal keeps its full height and its bottom rows - the prompt -
+        // sit behind the keyboard. Track the visual viewport instead; shrinking
+        // the container makes the iframe fire resize, and ttyd refits.
+
+        function trackOnScreenKeyboard() {
+            const viewport = window.visualViewport;
+            const container = document.getElementById('container');
+            if (!viewport || !container) return;
+
+            const apply = () => {
+                // A bogus height would collapse the terminal entirely.
+                if (viewport.height < 120) return;
+                container.style.height = viewport.height + 'px';
+                // iOS pans the layout viewport when an input takes focus.
+                window.scrollTo(0, 0);
+            };
+
+            viewport.addEventListener('resize', apply);
+            viewport.addEventListener('scroll', apply);
+            apply();
+        }
+
+        trackOnScreenKeyboard();
 
         // --- One-tap link copy ---
         // What people copy is almost always a login URL, and selecting it by

--- a/claude-terminal/image-service/public/terminal-clipboard.js
+++ b/claude-terminal/image-service/public/terminal-clipboard.js
@@ -400,6 +400,26 @@
         }, { passive: true });
     }
 
+    /**
+     * Stop the on-screen keyboard from composing.
+     *
+     * Gboard's predictive text keeps a composing region, and xterm.js re-emits
+     * a commit it has already sent (xtermjs/xterm.js#6060, open), so the same
+     * phrase lands in the prompt several times over. Nothing outside xterm.js
+     * can cancel what it sends, so the only lever left is to stop the keyboard
+     * composing at all: inputmode=url puts it in a plain, no-suggestions mode.
+     * The cost is the suggestion strip.
+     */
+    function installMobileInput(win, term) {
+        var textarea = term.textarea;
+        var coarse = !!(win.matchMedia && win.matchMedia('(pointer: coarse)').matches);
+        if (!textarea || !coarse) return false;
+
+        textarea.setAttribute('inputmode', 'url');
+        textarea.setAttribute('autocomplete', 'off');
+        return true;
+    }
+
     function install(win, options) {
         var opts = options || {};
         var term = win.term;
@@ -522,10 +542,26 @@
                 return last;
             },
             hasSelection: function () { return !!term.getSelection(); },
+            /**
+             * Settle the terminal after the viewport changed size.
+             *
+             * ttyd exposes fit() on the terminal it exports. Calling it pushes
+             * the new size through to the pty, and that SIGWINCH is what makes
+             * a full-screen app redraw with its prompt at the new bottom - the
+             * iframe's own resize event does not reliably land while the
+             * keyboard is still animating.
+             */
+            scrollToBottom: function () {
+                if (typeof term.fit === 'function') {
+                    try { term.fit(); } catch (err) { /* mid-teardown */ }
+                }
+                if (typeof term.scrollToBottom === 'function') term.scrollToBottom();
+            },
             copyTextDirect: copyText
         };
 
         installTouchScroll(win, term);
+        installMobileInput(win, term);
 
         term[INSTALL_FLAG] = true;
         term.__claudeClipboard = controller;
@@ -593,6 +629,7 @@
         readTerminalText: readTerminalText,
         findLastUrl: findLastUrl,
         findLinkInRows: findLinkInRows,
+        installMobileInput: installMobileInput,
         urlProblem: urlProblem,
         decodeBase64Utf8: decodeBase64Utf8,
         copyWithTextarea: copyWithTextarea,

--- a/claude-terminal/image-service/public/terminal-clipboard.js
+++ b/claude-terminal/image-service/public/terminal-clipboard.js
@@ -1,0 +1,540 @@
+/**
+ * Clipboard bridge for the embedded ttyd terminal. See CHANGELOG 2.1.0 and #30.
+ *
+ * ttyd 1.7.7 copies a selection with execCommand, which cannot see an xterm.js
+ * one, and registers no OSC 52 handler. Patched from here via window.term.
+ */
+(function (root, factory) {
+    'use strict';
+    var api = factory();
+    if (typeof module === 'object' && module.exports) {
+        module.exports = api;
+    }
+    if (root) {
+        root.ClaudeTerminalClipboard = api;
+    }
+})(typeof self !== 'undefined' ? self : null, function () {
+    'use strict';
+
+    var OSC_CLIPBOARD = 52;
+    var INSTALL_FLAG = '__claudeClipboardInstalled';
+    var TERM_POLL_INTERVAL_MS = 100;
+    var TERM_POLL_TIMEOUT_MS = 20000;
+
+    /** Decode the OSC 52 payload (base64 of UTF-8 bytes) using the frame's own globals. */
+    function decodeBase64Utf8(win, base64) {
+        var binary = win.atob(base64.replace(/\s+/g, ''));
+        var bytes = new win.Uint8Array(binary.length);
+        for (var i = 0; i < binary.length; i++) {
+            bytes[i] = binary.charCodeAt(i);
+        }
+        return new win.TextDecoder().decode(bytes);
+    }
+
+    // Insecure-origin fallback. Chrome only allows it during a user gesture,
+    // so it must stay synchronous.
+    function copyWithTextarea(win, text, nativeExecCommand) {
+        var doc = win.document;
+        if (!doc.body) return false;
+
+        var textarea = doc.createElement('textarea');
+        textarea.value = text;
+        textarea.setAttribute('readonly', '');
+        textarea.style.cssText = 'position:fixed;top:0;left:-9999px;width:1px;height:1px;opacity:0;';
+        doc.body.appendChild(textarea);
+
+        var previous = doc.activeElement;
+        var copied = false;
+        try {
+            textarea.focus();
+            textarea.select();
+            if (typeof textarea.setSelectionRange === 'function') {
+                textarea.setSelectionRange(0, text.length);
+            }
+            copied = nativeExecCommand('copy') === true;
+        } catch (err) {
+            copied = false;
+        }
+
+        doc.body.removeChild(textarea);
+        if (previous && typeof previous.focus === 'function') {
+            try { previous.focus(); } catch (err) { /* detached node */ }
+        }
+        return copied;
+    }
+
+    /** The single clipboard writer every path goes through. Resolves to success. */
+    function makeCopyText(win, nativeExecCommand) {
+        return function copyText(text) {
+            if (!text) return Promise.resolve(false);
+
+            var clipboard = win.navigator && win.navigator.clipboard;
+            if (clipboard && typeof clipboard.writeText === 'function') {
+                return clipboard.writeText(text).then(
+                    function () { return true; },
+                    // Rejects when the document is not focused, or when the
+                    // permission was denied - the textarea may still work.
+                    function () { return copyWithTextarea(win, text, nativeExecCommand); }
+                );
+            }
+            // No clipboard API: insecure context (http://homeassistant.local:8123).
+            return Promise.resolve(copyWithTextarea(win, text, nativeExecCommand));
+        };
+    }
+
+    // ttyd's overlay, reimplemented: its own is private and shows the scissors
+    // even when nothing was copied, which is the bug being fixed.
+    function createOverlay(win, term) {
+        var doc = win.document;
+        var node = doc.createElement('div');
+        node.className = 'claude-clipboard-overlay';
+        node.style.cssText = [
+            'border-radius: 15px',
+            'font-size: xx-large',
+            'opacity: 0.75',
+            'padding: 0.2em 0.5em 0.2em 0.5em',
+            'position: absolute',
+            'color: #101010',
+            'background-color: #f0f0f0',
+            'user-select: none',
+            '-webkit-user-select: none',
+            'transition: opacity 180ms ease-in',
+            'z-index: 10'
+        ].join(';');
+
+        var timer;
+
+        node.addEventListener('mousedown', function (event) {
+            // Never let the overlay start a new terminal selection.
+            event.preventDefault();
+            event.stopPropagation();
+        }, true);
+
+        function hide() {
+            if (timer) { win.clearTimeout(timer); timer = undefined; }
+            if (node.parentNode) node.parentNode.removeChild(node);
+        }
+
+        // Status only - never interactive. A control floating over the
+        // terminal has no room to explain itself; the page says it in words.
+        function show(message, timeoutMs) {
+            if (!term.element) return;
+            if (timer) { win.clearTimeout(timer); timer = undefined; }
+
+            node.textContent = message;
+            node.style.opacity = '0.75';
+
+            if (!node.parentNode) term.element.appendChild(node);
+
+            var box = term.element.getBoundingClientRect();
+            var size = node.getBoundingClientRect();
+            node.style.top = (box.height - size.height) / 2 + 'px';
+            node.style.left = (box.width - size.width) / 2 + 'px';
+
+            if (timeoutMs) timer = win.setTimeout(hide, timeoutMs);
+        }
+
+        return { show: show, hide: hide, node: node };
+    }
+
+    /**
+     * Terminal text from the xterm.js buffer - the only copy path a touch
+     * device has, since xterm.js has no touch selection and paints to a canvas.
+     *
+     * @param {'selection'|'screen'|'screen-down'|'all'} mode 'screen-down' adds
+     *   the rows below the viewport, so a line past the fold is not cut in half.
+     * @param {boolean} [joinWrapped=true]
+     */
+    function readTerminalText(term, mode, joinWrapped) {
+        return readRows(term, mode, joinWrapped).text;
+    }
+
+    /** The raw rows for a mode, each tagged with whether it filled the width. */
+    function rawRows(term, mode) {
+        var buffer = term.buffer.active;
+        var cols = term.cols;
+        var from;
+        var to;
+        if (mode === 'all') {
+            from = 0;
+            to = buffer.length - 1;
+        } else if (mode === 'screen-down') {
+            from = buffer.viewportY;
+            to = buffer.length - 1;
+        } else {
+            // The rows currently on screen, wherever the viewport is scrolled.
+            from = buffer.viewportY;
+            to = Math.min(from + term.rows - 1, buffer.length - 1);
+        }
+
+        var rows = [];
+        for (var y = from; y <= to; y++) {
+            var line = buffer.getLine(y);
+            if (!line) continue;
+            var text = line.translateToString(true);
+            rows.push({ text: text, full: text.length >= cols, wrapped: !!line.isWrapped });
+        }
+        return rows;
+    }
+
+    // As above, plus whether the last row was full. That flag is the only
+    // truncation signal: a URL cut mid-path reads as valid.
+    function readRows(term, mode, joinWrapped) {
+        if (mode === 'selection') {
+            return { text: term.getSelection() || '', lastRowFull: false };
+        }
+
+        var joined = joinRows(rawRows(term, mode), term.cols, joinWrapped !== false);
+        var lines = joined.lines;
+
+        // Drop the empty rows below the last output so a mostly-empty screen
+        // does not copy 20 blank lines.
+        while (lines.length && lines[lines.length - 1] === '') lines.pop();
+
+        return { text: lines.join('\n'), lastRowFull: joined.lastRowFull };
+    }
+
+    // Boundaries have to be guessed: exclude box-drawing glyphs, or Claude
+    // Code's prompt frame gets copied into the link.
+    var URL_PATTERN = /https?:\/\/[^\s"'<>`─-▟]+/g;
+    var TRAILING_PUNCTUATION = /[.,;:!?'"]+$/;
+    // A hostname with at least one dot and a letters-only TLD. "http://claude"
+    // or "http://…" is not something worth putting on the clipboard.
+    var PLAUSIBLE_HOST = /^https?:\/\/[^/?#\s]*[a-z0-9]([a-z0-9-]*[a-z0-9])?\.[a-z]{2,}(:\d+)?([/?#]|$)/i;
+
+    // Why a candidate is not worth copying. Half a URL is worse than none: it
+    // fails on paste with nothing on screen explaining why.
+    function urlProblem(url) {
+        if (!url) return 'none';
+        // A TUI that ran out of width ends the line with an ellipsis.
+        if (/(…|\.\.\.)$/.test(url)) return 'truncated';
+        // Cut inside a percent-escape, e.g. ".../a%3" or ".../a%".
+        if (/%[0-9a-f]?$/i.test(url)) return 'truncated';
+        // A query cut between parameters: "?a=1&" or "...&code=".
+        if (/[?&=]$/.test(url)) return 'truncated';
+        if (!PLAUSIBLE_HOST.test(url)) return 'invalid';
+        return null;
+    }
+
+    /**
+     * The last usable URL in terminal text, or null.
+     *
+     * @param {string} text
+     * @param {boolean} [reportProblem] return {url, problem} instead of a string
+     */
+    function findLastUrl(text, reportProblem) {
+        var fail = function (problem) {
+            return reportProblem ? { url: null, problem: problem } : null;
+        };
+        if (!text) return fail('none');
+        var matches = text.match(URL_PATTERN);
+        if (!matches) return fail('none');
+
+        var raw = matches[matches.length - 1];
+        // Checked before punctuation is stripped: "…" and "..." are how a TUI
+        // says "cut off here", and stripping them first would turn a truncated
+        // link into a plausible one. A single trailing dot is just a full stop.
+        if (/(…|\.\.\.)$/.test(raw)) return fail('truncated');
+
+        var url = raw.replace(TRAILING_PUNCTUATION, '');
+        // A closing bracket belongs to the URL only if it was opened inside it,
+        // so "(see http://x/a)" keeps the paren out but "http://x/a_(b)" keeps
+        // it in.
+        var pairs = { ')': '(', ']': '[', '}': '{' };
+        while (url && pairs[url.charAt(url.length - 1)]) {
+            var close = url.charAt(url.length - 1);
+            var open = pairs[close];
+            // Keep it when the URL opens at least as many as it closes.
+            if (url.split(open).length >= url.split(close).length) break;
+            url = url.slice(0, -1).replace(TRAILING_PUNCTUATION, '');
+        }
+
+        var problem = urlProblem(url);
+        if (problem) return fail(problem);
+        return reportProblem ? { url: url, problem: null } : url;
+    }
+
+    // What a wrapped URL may resume with. Letters are out: a row starting with
+    // one is usually the next line of output, not the rest of a link.
+    var URL_RESUMES = /^[/?&=#%~+.\-_0-9]/;
+    // A continuation holding any of these is a link tail, not a word.
+    var URL_TAIL = /[0-9/?&=#%~+.\-_]/;
+
+    // The column rows are really wrapped at - not the pane width, because
+    // Claude Code lays its output out one column short. A wrap column repeats,
+    // so take the widest length two rows share, near the pane width.
+    function wrapWidth(rows, cols) {
+        var floor = Math.max(1, cols - 2);
+        var counts = {};
+        var best = 0;
+        for (var i = 0; i < rows.length; i++) {
+            var len = rows[i].text.length;
+            if (len < floor || len > cols) continue;
+            counts[len] = (counts[len] || 0) + 1;
+            if (counts[len] >= 2 && len > best) best = len;
+        }
+        return best || cols;
+    }
+
+    // Rebuild the lines the terminal broke into rows. Three splits, each with
+    // its own trace: see CHANGELOG 2.1.0. The glue per boundary is nothing, one
+    // space, or a line break.
+    function joinRows(rows, cols, join) {
+        var lines = [];
+        var previousFull = false;
+        var previousLength = 0;
+        var width = wrapWidth(rows, cols);
+
+        for (var i = 0; i < rows.length; i++) {
+            var row = rows[i];
+            // Recomputed against the measured width, not the pane width.
+            row = { text: row.text, wrapped: row.wrapped, full: row.text.length >= width };
+            var chunk = row.text.replace(/^\s+/, '');
+            var indented = chunk !== row.text;
+            var glue = null;
+
+            if (join && lines.length && chunk !== '') {
+                if (previousFull || row.wrapped) {
+                    // One line; the question is whether the wrap ate a space.
+                    // A full or unindented row had no room for one. Otherwise
+                    // judge by shape: URL chars mean a tail, letters a word.
+                    if (!indented || row.full) {
+                        glue = '';
+                    } else {
+                        glue = URL_TAIL.test(chunk.split(/\s/)[0]) ? '' : ' ';
+                    }
+                } else {
+                    // A short row means the renderer chose to break. Rejoin
+                    // only when the next token could not have fitted anyway and
+                    // reads as the rest of a URL.
+                    var token = chunk.split(/\s/)[0];
+                    if (previousLength + token.length > width && URL_RESUMES.test(token)) {
+                        glue = '';
+                    }
+                }
+            }
+
+            if (glue === null) {
+                lines.push(row.text);
+            } else {
+                lines[lines.length - 1] += glue + chunk;
+            }
+            previousFull = row.full;
+            previousLength = row.text.length;
+        }
+
+        return { lines: lines, lastRowFull: previousFull };
+    }
+
+    // atEdge means the link runs off the rows given - widen, do not copy it.
+    function findLinkInRows(rows, cols) {
+        var joined = joinRows(rows, cols, true);
+        var text = joined.lines.join('\n');
+        var found = findLastUrl(text, true);
+
+        // Still growing when the rows ran out.
+        var atEdge = !!(found.url && joined.lastRowFull &&
+            text.slice(-found.url.length) === found.url);
+
+        return { url: found.url, problem: found.problem, atEdge: atEdge };
+    }
+
+    function install(win, options) {
+        var opts = options || {};
+        var term = win.term;
+        if (!term || term[INSTALL_FLAG]) return false;
+
+        var doc = win.document;
+        // Captured before the patch below, so our own fallback never recurses.
+        var originalExecCommand = doc.execCommand;
+        var nativeExecCommand = function (command) {
+            return originalExecCommand.call(doc, command);
+        };
+        var copyText = makeCopyText(win, nativeExecCommand);
+        var overlay = createOverlay(win, term);
+
+        // Scissors only on a real success. A refusal - only reachable for
+        // /copy on an insecure origin - goes to the page, which can say it in
+        // words and point at a button that has a gesture.
+        function report(text, copied) {
+            if (copied) {
+                overlay.show('✂', 200);
+                return;
+            }
+            overlay.show('⚠', 1200);
+            if (opts.onRefused) opts.onRefused(text);
+        }
+
+        // --- 1. Mouse selection ---
+        // Make ttyd's own execCommand('copy') throw, so it returns before
+        // showing its unconditional overlay. The real copy happens below.
+        doc.execCommand = function (command) {
+            if (command === 'copy' && term.getSelection()) {
+                throw new Error('claude-terminal: selection copy handled by the clipboard bridge');
+            }
+            return originalExecCommand.apply(doc, arguments);
+        };
+
+        var dragging = false;
+        var pending = null;
+
+        function flush() {
+            var text = pending;
+            pending = null;
+            if (!text) return;
+            copyText(text).then(function (copied) { report(text, copied); });
+        }
+
+        term.onSelectionChange(function () {
+            var selection = term.getSelection();
+            if (!selection) return;
+            pending = selection;
+            // While dragging, wait for mouseup: one copy per gesture, and the
+            // textarea fallback stays inside the gesture that Chrome requires.
+            if (!dragging) flush();
+        });
+
+        if (term.element) {
+            term.element.addEventListener('mousedown', function () { dragging = true; }, true);
+        }
+        win.addEventListener('mouseup', function () {
+            if (!dragging) return;
+            dragging = false;
+            flush();
+        }, true);
+
+        // --- 2. OSC 52 (Claude Code's /copy, via tmux) -------------------------
+        term.parser.registerOscHandler(OSC_CLIPBOARD, function (data) {
+            var separator = data.indexOf(';');
+            // `data` is everything after "52;", i.e. "<Pc>;<Pd>". Some senders
+            // omit Pc, leaving just the payload.
+            var payload = separator === -1 ? data : data.slice(separator + 1);
+
+            // A read request would hand the host clipboard to whatever runs in
+            // the terminal. Swallow it instead of answering.
+            if (payload === '?') return true;
+
+            var text = '';
+            try {
+                text = decodeBase64Utf8(win, payload);
+            } catch (err) {
+                return true;
+            }
+            if (!text) return true;
+
+            copyText(text).then(function (copied) { report(text, copied); });
+            return true; // handled - do not print the escape sequence
+        });
+
+        // --- 3. Touch devices --------------------------------------------------
+        // Nothing above helps a phone: no mouse selection exists, and /copy's
+        // fallback needs a gesture. The controller lets the page drive a copy
+        // from a button tap, which is a gesture.
+        var controller = {
+            copy: function (mode, joinWrapped) {
+                var text = readTerminalText(term, mode || 'screen', joinWrapped);
+                if (!text) return Promise.resolve({ copied: false, text: '' });
+                return copyText(text).then(function (copied) {
+                    if (copied) overlay.show('✂', 200);
+                    return { copied: copied, text: text };
+                });
+            },
+            read: function (mode, joinWrapped) {
+                return readTerminalText(term, mode || 'screen', joinWrapped);
+            },
+            // Widens screen -> screen-down -> scrollback, because a link
+            // running off the rows read is the half-URL users end up pasting.
+            // Returns {url, problem: 'none'|'truncated'|'invalid'}.
+            findLink: function () {
+                var modes = ['screen', 'screen-down', 'all'];
+                var last = { url: null, problem: 'none' };
+                for (var i = 0; i < modes.length; i++) {
+                    var found = findLinkInRows(rawRows(term, modes[i]), term.cols);
+
+                    if (found.atEdge) {
+                        last = { url: null, problem: 'truncated' };
+                        continue;
+                    }
+                    if (found.url) return { url: found.url, problem: null };
+                    if (found.problem !== 'none') last = { url: null, problem: found.problem };
+                }
+                return last;
+            },
+            hasSelection: function () { return !!term.getSelection(); },
+            copyTextDirect: copyText
+        };
+
+        term[INSTALL_FLAG] = true;
+        term.__claudeClipboard = controller;
+        return controller;
+    }
+
+    /**
+     * Attach to a same-origin iframe running ttyd. Re-arms on every reload,
+     * and waits for `window.term`, which ttyd sets when the terminal opens.
+     */
+    function attach(iframe, options) {
+        var opts = options || {};
+        var timeoutMs = opts.timeoutMs || TERM_POLL_TIMEOUT_MS;
+        var intervalMs = opts.intervalMs || TERM_POLL_INTERVAL_MS;
+        var scheduler = opts.scheduler || {
+            setTimeout: function (fn, ms) { return setTimeout(fn, ms); },
+            clearTimeout: function (id) { return clearTimeout(id); }
+        };
+        var timer;
+        var controller = null;
+
+        function poll(deadline) {
+            var win;
+            try {
+                win = iframe.contentWindow;
+            } catch (err) {
+                return; // cross-origin: nothing we can do
+            }
+            // ttyd assigns window.term just before terminal.open(), so wait for
+            // the DOM element too - the mousedown listener needs it.
+            if (win && win.term && win.term.element) {
+                try {
+                    controller = install(win, { onRefused: opts.onRefused }) ||
+                        win.term.__claudeClipboard || null;
+                    if (controller && opts.onReady) opts.onReady(controller);
+                } catch (err) {
+                    if (opts.onError) opts.onError(err);
+                }
+                return;
+            }
+            if (deadline <= 0) {
+                if (opts.onTimeout) opts.onTimeout();
+                return;
+            }
+            timer = scheduler.setTimeout(function () { poll(deadline - intervalMs); }, intervalMs);
+        }
+
+        function restart() {
+            if (timer) scheduler.clearTimeout(timer);
+            poll(timeoutMs);
+        }
+
+        iframe.addEventListener('load', restart);
+        restart();
+        return {
+            restart: restart,
+            // null until the terminal is up; the page must handle that.
+            getController: function () { return controller; }
+        };
+    }
+
+    return {
+        attach: attach,
+        install: install,
+        readTerminalText: readTerminalText,
+        findLastUrl: findLastUrl,
+        findLinkInRows: findLinkInRows,
+        urlProblem: urlProblem,
+        decodeBase64Utf8: decodeBase64Utf8,
+        copyWithTextarea: copyWithTextarea,
+        makeCopyText: makeCopyText,
+        createOverlay: createOverlay,
+        OSC_CLIPBOARD: OSC_CLIPBOARD
+    };
+});

--- a/claude-terminal/image-service/public/terminal-clipboard.js
+++ b/claude-terminal/image-service/public/terminal-clipboard.js
@@ -339,6 +339,67 @@
         return { url: found.url, problem: found.problem, atEdge: atEdge };
     }
 
+    var TOUCH_LINES_PER_MOVE = 8;
+
+    /**
+     * Scroll by swiping. xterm.js 5.5 drops touchstart/touchmove outright while
+     * the app has mouse reporting on, and never turns touch into a mouse
+     * report - so with Claude Code (reporting on, alternate screen) a phone
+     * cannot scroll at all. The wheel has its own path, which is why a mouse
+     * works. Swipes become wheel events, so xterm.js encodes them exactly as it
+     * would a real wheel: a mouse report if the app wants one, else a scroll.
+     */
+    function installTouchScroll(win, term) {
+        var el = term.element;
+        if (!el) return;
+
+        // Vertical is ours; leave pinch-zoom and horizontal pan to the browser.
+        el.style.touchAction = 'pan-x pinch-zoom';
+
+        var lastY = null;
+        var pending = 0;
+
+        el.addEventListener('touchstart', function (ev) {
+            lastY = ev.touches.length === 1 ? ev.touches[0].clientY : null;
+            pending = 0;
+        }, { passive: true });
+
+        el.addEventListener('touchmove', function (ev) {
+            // xterm.js prevents the default when it scrolled the viewport
+            // itself - its signal that the gesture is already handled.
+            if (lastY === null || ev.defaultPrevented || ev.touches.length !== 1) return;
+
+            var touch = ev.touches[0];
+            var step = Math.max(1, el.getBoundingClientRect().height / Math.max(1, term.rows));
+            pending += lastY - touch.clientY;
+            lastY = touch.clientY;
+
+            var lines = Math.trunc(pending / step);
+            if (!lines) return;
+            pending -= lines * step;
+            ev.preventDefault();
+
+            // One event per line: a mouse report carries a direction, not a
+            // distance, so a single large delta would scroll one line.
+            var count = Math.min(Math.abs(lines), TOUCH_LINES_PER_MOVE);
+            for (var i = 0; i < count; i++) {
+                el.dispatchEvent(new win.WheelEvent('wheel', {
+                    deltaY: lines > 0 ? step : -step,
+                    deltaMode: 0,
+                    clientX: touch.clientX,
+                    clientY: touch.clientY,
+                    bubbles: true,
+                    cancelable: true
+                }));
+            }
+        }, { passive: false });
+
+        el.addEventListener('touchend', function () {
+            lastY = null;
+            pending = 0;
+        }, { passive: true });
+    }
+
     function install(win, options) {
         var opts = options || {};
         var term = win.term;
@@ -463,6 +524,8 @@
             hasSelection: function () { return !!term.getSelection(); },
             copyTextDirect: copyText
         };
+
+        installTouchScroll(win, term);
 
         term[INSTALL_FLAG] = true;
         term.__claudeClipboard = controller;

--- a/claude-terminal/image-service/public/terminal-clipboard.js
+++ b/claude-terminal/image-service/public/terminal-clipboard.js
@@ -350,6 +350,13 @@
         return buffer.length > term.rows;
     }
 
+    // xterm.js carries this class exactly while the application has mouse
+    // reporting on. Then a wheel event leaves as a mouse report instead of
+    // being turned into arrow keys, so passing one on is safe.
+    function appTakesWheel(el) {
+        return !!(el.classList && el.classList.contains('enable-mouse-events'));
+    }
+
     /**
      * Scroll by swiping. xterm.js 5.5 drops touchstart/touchmove outright while
      * the app has mouse reporting on, and never turns touch into a mouse
@@ -377,12 +384,11 @@
             // xterm.js prevents the default when it scrolled the viewport
             // itself - its signal that the gesture is already handled.
             if (lastY === null || ev.defaultPrevented || ev.touches.length !== 1) return;
-            // With no scrollback, xterm.js turns a wheel event into arrow keys
-            // and sends them as INPUT. Under tmux that means every swipe walks
-            // Claude Code's message history into the prompt. Scrolling a
-            // full-screen app needs real mouse reporting (the tmux_mouse
-            // option); without it a swipe must do nothing at all.
-            if (!hasScrollback(term)) return;
+            // With no scrollback and no mouse reporting, xterm.js turns a wheel
+            // event into arrow keys and sends them as INPUT - under tmux that
+            // walks Claude Code's message history into the prompt. Swipe only
+            // where the wheel stays a wheel.
+            if (!appTakesWheel(el) && !hasScrollback(term)) return;
 
             var touch = ev.touches[0];
             var step = Math.max(1, el.getBoundingClientRect().height / Math.max(1, term.rows));

--- a/claude-terminal/image-service/public/terminal-clipboard.js
+++ b/claude-terminal/image-service/public/terminal-clipboard.js
@@ -438,29 +438,10 @@
 
         textarea.setAttribute('autocomplete', 'off');
 
-        // xterm.js only empties the helper textarea on Enter or Ctrl+C, so a
-        // long stretch of typing leaves the whole sentence sitting in it. The
-        // keyboard keeps a composing region over that text, and every commit
-        // re-sends all of it - which is why the prompt filled up with the same
-        // phrase again and again, and why reloading the page cured it.
-        //
-        // Emptying it after each committed keystroke keeps the region small.
-        // The value is only there for IMEs and screen readers; the keystrokes
-        // themselves have already been sent by the time this runs, because
-        // xterm.js listens in the capture phase and this listens in the bubble
-        // phase.
-        var composing = false;
-
-        textarea.addEventListener('compositionstart', function () { composing = true; });
-        textarea.addEventListener('compositionend', function () {
-            composing = false;
-            textarea.value = '';
-        });
-        textarea.addEventListener('input', function () {
-            // Clearing mid-composition would destroy the word being typed.
-            if (!composing) textarea.value = '';
-        });
-
+        // Nothing else. Emptying the textarea after each keystroke was tried
+        // and reverted: Gboard commits a word only once the space key lands,
+        // so clearing on `input` deleted the word being typed. The repeated
+        // text is xtermjs/xterm.js#6060 and has to be fixed there.
         return true;
     }
 

--- a/claude-terminal/image-service/public/terminal-clipboard.js
+++ b/claude-terminal/image-service/public/terminal-clipboard.js
@@ -421,16 +421,9 @@
         }, { passive: true });
     }
 
-    /**
-     * Stop the on-screen keyboard from composing.
-     *
-     * Gboard's predictive text keeps a composing region, and xterm.js re-emits
-     * a commit it has already sent (xtermjs/xterm.js#6060, open), so the same
-     * phrase lands in the prompt several times over. Nothing outside xterm.js
-     * can cancel what it sends, so the only lever left is to stop the keyboard
-     * composing at all: inputmode=url puts it in a plain, no-suggestions mode.
-     * The cost is the suggestion strip.
-     */
+    // Only a hint that this is not a form field. Two attempts at curing the
+    // repeated text (xtermjs/xterm.js#6060) were tried here and reverted -
+    // see the comment inside.
     function installMobileInput(win, term) {
         var textarea = term.textarea;
         var coarse = !!(win.matchMedia && win.matchMedia('(pointer: coarse)').matches);

--- a/claude-terminal/image-service/public/terminal-clipboard.js
+++ b/claude-terminal/image-service/public/terminal-clipboard.js
@@ -341,6 +341,15 @@
 
     var TOUCH_LINES_PER_MOVE = 8;
 
+    // Mirrors the check xterm.js makes before it converts a wheel event into
+    // arrow keys. The alternate buffer never has scrollback, and that is what
+    // tmux and every full-screen app runs in.
+    function hasScrollback(term) {
+        var buffer = term.buffer && term.buffer.active;
+        if (!buffer || buffer.type !== 'normal') return false;
+        return buffer.length > term.rows;
+    }
+
     /**
      * Scroll by swiping. xterm.js 5.5 drops touchstart/touchmove outright while
      * the app has mouse reporting on, and never turns touch into a mouse
@@ -368,6 +377,12 @@
             // xterm.js prevents the default when it scrolled the viewport
             // itself - its signal that the gesture is already handled.
             if (lastY === null || ev.defaultPrevented || ev.touches.length !== 1) return;
+            // With no scrollback, xterm.js turns a wheel event into arrow keys
+            // and sends them as INPUT. Under tmux that means every swipe walks
+            // Claude Code's message history into the prompt. Scrolling a
+            // full-screen app needs real mouse reporting (the tmux_mouse
+            // option); without it a swipe must do nothing at all.
+            if (!hasScrollback(term)) return;
 
             var touch = ev.touches[0];
             var step = Math.max(1, el.getBoundingClientRect().height / Math.max(1, term.rows));

--- a/claude-terminal/image-service/public/terminal-clipboard.js
+++ b/claude-terminal/image-service/public/terminal-clipboard.js
@@ -436,8 +436,31 @@
         var coarse = !!(win.matchMedia && win.matchMedia('(pointer: coarse)').matches);
         if (!textarea || !coarse) return false;
 
-        textarea.setAttribute('inputmode', 'url');
         textarea.setAttribute('autocomplete', 'off');
+
+        // xterm.js only empties the helper textarea on Enter or Ctrl+C, so a
+        // long stretch of typing leaves the whole sentence sitting in it. The
+        // keyboard keeps a composing region over that text, and every commit
+        // re-sends all of it - which is why the prompt filled up with the same
+        // phrase again and again, and why reloading the page cured it.
+        //
+        // Emptying it after each committed keystroke keeps the region small.
+        // The value is only there for IMEs and screen readers; the keystrokes
+        // themselves have already been sent by the time this runs, because
+        // xterm.js listens in the capture phase and this listens in the bubble
+        // phase.
+        var composing = false;
+
+        textarea.addEventListener('compositionstart', function () { composing = true; });
+        textarea.addEventListener('compositionend', function () {
+            composing = false;
+            textarea.value = '';
+        });
+        textarea.addEventListener('input', function () {
+            // Clearing mid-composition would destroy the word being typed.
+            if (!composing) textarea.value = '';
+        });
+
         return true;
     }
 

--- a/claude-terminal/run.sh
+++ b/claude-terminal/run.sh
@@ -211,6 +211,14 @@ setup_tmux() {
 # Mouse mode is disabled by default so ttyd/browser copy and paste keeps working.
 set -g mouse ${tmux_mouse}
 
+# Let applications in the pane (Claude Code's /copy) set the clipboard through
+# OSC 52 and forward it out to ttyd. The default 'external' drops what they send.
+set -g set-clipboard on
+
+# tmux only emits OSC 52 when the outer terminal advertises the 'Ms' capability.
+# ttyd's frontend always accepts it, so declare it instead of trusting terminfo.
+set -as terminal-features ',*:clipboard'
+
 # Large scrollback buffer
 set -g history-limit 50000
 

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -5,5 +5,6 @@ tests_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 
 "$tests_dir/test-production-run.sh"
 "$tests_dir/test-persistent-packages.sh"
+node "$tests_dir/test-terminal-clipboard.js"
 
 echo "All regression suites passed"

--- a/tests/test-production-run.sh
+++ b/tests/test-production-run.sh
@@ -48,6 +48,23 @@ config_tmux_mouse=''
 setup_tmux
 grep -qx 'set -g mouse off' "$HOME/.tmux.conf" || fail "empty optional bool should safely disable mouse mode"
 
+# Claude Code's /copy emits OSC 52. tmux defaults to set-clipboard=external, which
+# drops what applications in the pane send, and only emits OSC 52 outwards when the
+# outer terminal advertises the Ms capability.
+grep -qx 'set -g set-clipboard on' "$HOME/.tmux.conf" || \
+    fail "tmux must accept and forward OSC 52 from applications"
+grep -qx "set -as terminal-features ',\*:clipboard'" "$HOME/.tmux.conf" || \
+    fail "tmux must advertise the clipboard capability so OSC 52 reaches ttyd"
+
+# The frontend fix has to be reachable from the page that embeds ttyd.
+clipboard_bridge="$repo_root/claude-terminal/image-service/public/terminal-clipboard.js"
+terminal_page="$repo_root/claude-terminal/image-service/public/index.html"
+[ -f "$clipboard_bridge" ] || fail "clipboard bridge is missing"
+grep -q 'src="terminal-clipboard.js"' "$terminal_page" || \
+    fail "terminal page must load the clipboard bridge"
+grep -q 'installTerminalClipboard(iframe)' "$terminal_page" || \
+    fail "terminal page must attach the clipboard bridge to the ttyd iframe"
+
 PERSISTENT_CLAUDE_ROOT="$tmp_dir/npm"
 CLAUDE_BIN_LINK="$tmp_dir/claude"
 mkdir -p "$PERSISTENT_CLAUDE_ROOT/bin" \

--- a/tests/test-production-run.sh
+++ b/tests/test-production-run.sh
@@ -69,6 +69,8 @@ grep -q 'installTerminalClipboard(iframe)' "$terminal_page" || \
 # this the prompt ends up behind the keyboard.
 grep -q 'window.visualViewport' "$terminal_page" || \
     fail "terminal page must follow the visual viewport so the keyboard cannot cover the prompt"
+grep -q 'interactive-widget=resizes-content' "$terminal_page" || \
+    fail "the viewport must shrink with the on-screen keyboard, not sit behind it"
 
 PERSISTENT_CLAUDE_ROOT="$tmp_dir/npm"
 CLAUDE_BIN_LINK="$tmp_dir/claude"

--- a/tests/test-production-run.sh
+++ b/tests/test-production-run.sh
@@ -65,6 +65,11 @@ grep -q 'src="terminal-clipboard.js"' "$terminal_page" || \
 grep -q 'installTerminalClipboard(iframe)' "$terminal_page" || \
     fail "terminal page must attach the clipboard bridge to the ttyd iframe"
 
+# The on-screen keyboard shrinks the visual viewport but not 100vh, so without
+# this the prompt ends up behind the keyboard.
+grep -q 'window.visualViewport' "$terminal_page" || \
+    fail "terminal page must follow the visual viewport so the keyboard cannot cover the prompt"
+
 PERSISTENT_CLAUDE_ROOT="$tmp_dir/npm"
 CLAUDE_BIN_LINK="$tmp_dir/claude"
 mkdir -p "$PERSISTENT_CLAUDE_ROOT/bin" \

--- a/tests/test-terminal-clipboard.js
+++ b/tests/test-terminal-clipboard.js
@@ -1040,19 +1040,41 @@ test('touchend releases the gesture', () => {
 // the prompt several times over. Nothing outside xterm.js can cancel what it
 // sends, so the keyboard is put in a non-composing mode instead.
 
-test('a touch device gets a keyboard that does not compose', () => {
+test('the helper textarea is emptied after every committed keystroke', () => {
+    // xterm.js only clears it on Enter or Ctrl+C, so a long stretch of typing
+    // leaves the whole sentence in it for the keyboard to keep composing over,
+    // and each commit re-sends all of it.
     const env = makeWindow({ clipboardApi: true, touch: true });
     bridge.install(env.win);
+    const textarea = env.win.term.textarea;
 
-    assert.strictEqual(env.win.term.textarea.attributes.inputmode, 'url');
-    assert.strictEqual(env.win.term.textarea.attributes.autocomplete, 'off');
+    textarea.value = 'a whole sentence typed without pressing enter';
+    textarea.dispatch('input');
+    assert.strictEqual(textarea.value, '', 'nothing must be left to re-send');
 });
 
-test('a mouse keeps its normal keyboard', () => {
+test('the textarea is left alone while a word is being composed', () => {
+    const env = makeWindow({ clipboardApi: true, touch: true });
+    bridge.install(env.win);
+    const textarea = env.win.term.textarea;
+
+    textarea.dispatch('compositionstart');
+    textarea.value = 'partia';
+    textarea.dispatch('input');
+    assert.strictEqual(textarea.value, 'partia', 'clearing here would destroy the word');
+
+    textarea.dispatch('compositionend');
+    assert.strictEqual(textarea.value, '', 'but it goes once the word is committed');
+});
+
+test('a mouse keyboard is not touched at all', () => {
     const env = makeWindow({ clipboardApi: true, touch: false });
     bridge.install(env.win);
+    const textarea = env.win.term.textarea;
 
-    assert.strictEqual(env.win.term.textarea.attributes.inputmode, undefined);
+    textarea.value = 'desktop typing';
+    textarea.dispatch('input');
+    assert.strictEqual(textarea.value, 'desktop typing');
 });
 
 test('a terminal with no textarea is left alone', () => {

--- a/tests/test-terminal-clipboard.js
+++ b/tests/test-terminal-clipboard.js
@@ -41,9 +41,16 @@ function makeElement(tag) {
             if (!listeners.has(type)) listeners.set(type, []);
             listeners.get(type).push(handler);
         },
-        dispatch(type) {
-            const event = { preventDefault() {}, stopPropagation() {} };
+        dispatched: [],
+        dispatchEvent(event) { this.dispatched.push(event); return true; },
+        dispatch(type, extra) {
+            const event = Object.assign({
+                defaultPrevented: false,
+                preventDefault() { this.defaultPrevented = true; },
+                stopPropagation() {}
+            }, extra || {});
             (listeners.get(type) || []).forEach(handler => handler(event));
+            return event;
         },
         focus() {},
         select() {},
@@ -88,6 +95,8 @@ function makeWindow(options) {
         TextDecoder,
         setTimeout: (fn, ms) => setTimeout(fn, ms),
         clearTimeout: id => clearTimeout(id),
+        // Stands in for the iframe's WheelEvent constructor.
+        WheelEvent: function (type, init) { return Object.assign({ type: type }, init); },
         addEventListener(type, handler) {
             if (!windowListeners.has(type)) windowListeners.set(type, []);
             windowListeners.get(type).push(handler);
@@ -837,6 +846,140 @@ test('the link is found across tmux-wrapped rows, not as two halves', () => {
     });
     const controller = bridge.install(env.win);
     assert.strictEqual(controller.findLink().url, 'https://claude.com/oauth?code=1');
+});
+
+// --- Touch scrolling ------------------------------------------------------
+// xterm.js 5.5 drops touchstart/touchmove while the app has mouse reporting on
+// and never turns touch into a mouse report, so a phone could not scroll at
+// all. Measured on the live terminal: alternate_on=1, mouse_any_flag=1.
+// A row is 40/20 = 2px tall in this fixture (element height 40, rows 20).
+
+const swipe = (env, from, to, extra) => {
+    env.termElement.dispatch('touchstart', { touches: [{ clientY: from, clientX: 5 }] });
+    return env.termElement.dispatch('touchmove',
+        Object.assign({ touches: [{ clientY: to, clientX: 5 }] }, extra || {}));
+};
+const wheels = env => env.termElement.dispatched.filter(e => e.type === 'wheel');
+
+test('swiping down scrolls back, one wheel event per row', () => {
+    const env = makeWindow({ clipboardApi: true, rows: 20 });
+    bridge.install(env.win);
+
+    swipe(env, 100, 106); // finger down 6px = 3 rows
+    const sent = wheels(env);
+    assert.strictEqual(sent.length, 3, 'one event per row, not one per gesture');
+    assert.ok(sent.every(e => e.deltaY < 0), 'dragging content down reveals older output');
+});
+
+test('swiping up scrolls forward', () => {
+    const env = makeWindow({ clipboardApi: true, rows: 20 });
+    bridge.install(env.win);
+
+    swipe(env, 100, 94);
+    assert.ok(wheels(env).every(e => e.deltaY > 0));
+});
+
+test('a move shorter than one row scrolls nothing yet', () => {
+    const env = makeWindow({ clipboardApi: true, rows: 20 });
+    bridge.install(env.win);
+
+    swipe(env, 100, 101); // 1px, row is 2px
+    assert.deepStrictEqual(wheels(env), []);
+});
+
+test('sub-row moves accumulate instead of being discarded', () => {
+    const env = makeWindow({ clipboardApi: true, rows: 20 });
+    bridge.install(env.win);
+
+    env.termElement.dispatch('touchstart', { touches: [{ clientY: 100, clientX: 5 }] });
+    env.termElement.dispatch('touchmove', { touches: [{ clientY: 101, clientX: 5 }] });
+    assert.deepStrictEqual(wheels(env), [], 'not yet a full row');
+    env.termElement.dispatch('touchmove', { touches: [{ clientY: 102, clientX: 5 }] });
+    assert.strictEqual(wheels(env).length, 1, 'the two halves make one row');
+});
+
+test('the leftover of a partial row carries into the next move', () => {
+    // 3px with a 2px row is one row and 1px over. Dropping that remainder
+    // instead of keeping it makes a slow drag lose about half its distance.
+    const env = makeWindow({ clipboardApi: true, rows: 20 });
+    bridge.install(env.win);
+
+    env.termElement.dispatch('touchstart', { touches: [{ clientY: 100, clientX: 5 }] });
+    env.termElement.dispatch('touchmove', { touches: [{ clientY: 103, clientX: 5 }] });
+    assert.strictEqual(wheels(env).length, 1);
+    env.termElement.dispatch('touchmove', { touches: [{ clientY: 104, clientX: 5 }] });
+    assert.strictEqual(wheels(env).length, 2, '1px left over plus 1px is a second row');
+});
+
+test('a sub-row move leaves the gesture to the browser', () => {
+    // Claiming a move that scrolled nothing would swallow taps and flings.
+    const env = makeWindow({ clipboardApi: true, rows: 20 });
+    bridge.install(env.win);
+
+    env.termElement.dispatch('touchstart', { touches: [{ clientY: 100, clientX: 5 }] });
+    const ev = env.termElement.dispatch('touchmove', { touches: [{ clientY: 101, clientX: 5 }] });
+    assert.strictEqual(ev.defaultPrevented, false);
+});
+
+test('a second finger mid-gesture stops the scroll', () => {
+    // Starting one-fingered and then pinching must not keep scrolling.
+    const env = makeWindow({ clipboardApi: true, rows: 20 });
+    bridge.install(env.win);
+
+    env.termElement.dispatch('touchstart', { touches: [{ clientY: 100, clientX: 5 }] });
+    env.termElement.dispatch('touchmove', {
+        touches: [{ clientY: 110, clientX: 5 }, { clientY: 200, clientX: 5 }]
+    });
+    assert.deepStrictEqual(wheels(env), []);
+});
+
+test('the gesture is claimed, or the browser would treat it as a page scroll', () => {
+    const env = makeWindow({ clipboardApi: true, rows: 20 });
+    bridge.install(env.win);
+
+    const ev = swipe(env, 100, 106);
+    assert.strictEqual(ev.defaultPrevented, true);
+    assert.strictEqual(
+        env.termElement.style.touchAction, 'pan-x pinch-zoom',
+        'vertical must be ours while pinch-zoom stays with the browser'
+    );
+});
+
+test('a gesture xterm.js already handled is left alone', () => {
+    // xterm.js prevents the default when it scrolled the viewport itself.
+    const env = makeWindow({ clipboardApi: true, rows: 20 });
+    bridge.install(env.win);
+
+    swipe(env, 100, 106, { defaultPrevented: true });
+    assert.deepStrictEqual(wheels(env), [], 'must not scroll twice');
+});
+
+test('two fingers are left to the browser for pinch-zoom', () => {
+    const env = makeWindow({ clipboardApi: true, rows: 20 });
+    bridge.install(env.win);
+
+    env.termElement.dispatch('touchstart', { touches: [{ clientY: 100, clientX: 5 }, { clientY: 200, clientX: 5 }] });
+    env.termElement.dispatch('touchmove', { touches: [{ clientY: 106, clientX: 5 }, { clientY: 190, clientX: 5 }] });
+    assert.deepStrictEqual(wheels(env), []);
+});
+
+test('a fling is capped so one gesture cannot flood the app', () => {
+    const env = makeWindow({ clipboardApi: true, rows: 20 });
+    bridge.install(env.win);
+
+    swipe(env, 500, 900); // 400px = 200 rows
+    assert.strictEqual(wheels(env).length, 8);
+});
+
+test('touchend releases the gesture', () => {
+    const env = makeWindow({ clipboardApi: true, rows: 20 });
+    bridge.install(env.win);
+
+    swipe(env, 100, 106);
+    const before = wheels(env).length;
+    env.termElement.dispatch('touchend', {});
+    env.termElement.dispatch('touchmove', { touches: [{ clientY: 200, clientX: 5 }] });
+    assert.strictEqual(wheels(env).length, before, 'a move after touchend is not a swipe');
 });
 
 (async () => {

--- a/tests/test-terminal-clipboard.js
+++ b/tests/test-terminal-clipboard.js
@@ -1040,41 +1040,20 @@ test('touchend releases the gesture', () => {
 // the prompt several times over. Nothing outside xterm.js can cancel what it
 // sends, so the keyboard is put in a non-composing mode instead.
 
-test('the helper textarea is emptied after every committed keystroke', () => {
-    // xterm.js only clears it on Enter or Ctrl+C, so a long stretch of typing
-    // leaves the whole sentence in it for the keyboard to keep composing over,
-    // and each commit re-sends all of it.
+test('typing is never interfered with', () => {
+    // Emptying the textarea after each keystroke was tried and reverted:
+    // Gboard commits a word only when space lands, so clearing on `input`
+    // deleted the word being typed.
     const env = makeWindow({ clipboardApi: true, touch: true });
     bridge.install(env.win);
     const textarea = env.win.term.textarea;
 
-    textarea.value = 'a whole sentence typed without pressing enter';
+    textarea.value = 'slovo';
     textarea.dispatch('input');
-    assert.strictEqual(textarea.value, '', 'nothing must be left to re-send');
-});
-
-test('the textarea is left alone while a word is being composed', () => {
-    const env = makeWindow({ clipboardApi: true, touch: true });
-    bridge.install(env.win);
-    const textarea = env.win.term.textarea;
-
-    textarea.dispatch('compositionstart');
-    textarea.value = 'partia';
-    textarea.dispatch('input');
-    assert.strictEqual(textarea.value, 'partia', 'clearing here would destroy the word');
+    assert.strictEqual(textarea.value, 'slovo', 'the word must survive');
 
     textarea.dispatch('compositionend');
-    assert.strictEqual(textarea.value, '', 'but it goes once the word is committed');
-});
-
-test('a mouse keyboard is not touched at all', () => {
-    const env = makeWindow({ clipboardApi: true, touch: false });
-    bridge.install(env.win);
-    const textarea = env.win.term.textarea;
-
-    textarea.value = 'desktop typing';
-    textarea.dispatch('input');
-    assert.strictEqual(textarea.value, 'desktop typing');
+    assert.strictEqual(textarea.value, 'slovo');
 });
 
 test('a terminal with no textarea is left alone', () => {

--- a/tests/test-terminal-clipboard.js
+++ b/tests/test-terminal-clipboard.js
@@ -37,6 +37,12 @@ function makeElement(tag) {
             return child;
         },
         getBoundingClientRect() { return { width: 100, height: 40 }; },
+        classList: {
+            _set: new Set(),
+            add(name) { this._set.add(name); },
+            remove(name) { this._set.delete(name); },
+            contains(name) { return this._set.has(name); }
+        },
         addEventListener(type, handler) {
             if (!listeners.has(type)) listeners.set(type, []);
             listeners.get(type).push(handler);
@@ -873,6 +879,18 @@ const swipe = (env, from, to, extra) => {
         Object.assign({ touches: [{ clientY: to, clientX: 5 }] }, extra || {}));
 };
 const wheels = env => env.termElement.dispatched.filter(e => e.type === 'wheel');
+
+test('a swipe scrolls a full-screen app once it takes the mouse', () => {
+    // With mouse reporting on (the tmux_mouse option) a wheel event leaves as
+    // a mouse report, so it is safe to pass on even with no scrollback - and
+    // it is the only way to scroll a full-screen app.
+    const env = makeWindow({ clipboardApi: true, rows: 20, altScreen: true, buffer: SCROLLBACK });
+    bridge.install(env.win);
+    env.termElement.classList.add('enable-mouse-events');
+
+    swipe(env, 100, 106);
+    assert.strictEqual(wheels(env).length, 3);
+});
 
 test('a swipe sends nothing when there is no scrollback', () => {
     // xterm.js turns a wheel event into arrow keys when the buffer has no

--- a/tests/test-terminal-clipboard.js
+++ b/tests/test-terminal-clipboard.js
@@ -1,0 +1,857 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * Regression tests for the ttyd clipboard bridge - the two things ttyd 1.7.7
+ * gets wrong (selection copy, OSC 52) plus the insecure-origin fallback.
+ */
+
+const path = require('path');
+const assert = require('assert');
+
+const bridge = require(
+    path.join(__dirname, '..', 'claude-terminal', 'image-service', 'public', 'terminal-clipboard.js')
+);
+
+let failures = 0;
+const tests = [];
+function test(name, fn) { tests.push([name, fn]); }
+const tick = () => new Promise(resolve => setImmediate(resolve));
+
+// --- Minimal DOM good enough for the bridge -------------------------------
+function makeElement(tag) {
+    const listeners = new Map();
+    return {
+        tagName: tag,
+        children: [],
+        parentNode: null,
+        textContent: '',
+        style: { cssText: '' },
+        value: '',
+        attributes: {},
+        setAttribute(name, value) { this.attributes[name] = value; },
+        appendChild(child) { this.children.push(child); child.parentNode = this; return child; },
+        removeChild(child) {
+            this.children = this.children.filter(c => c !== child);
+            child.parentNode = null;
+            return child;
+        },
+        getBoundingClientRect() { return { width: 100, height: 40 }; },
+        addEventListener(type, handler) {
+            if (!listeners.has(type)) listeners.set(type, []);
+            listeners.get(type).push(handler);
+        },
+        dispatch(type) {
+            const event = { preventDefault() {}, stopPropagation() {} };
+            (listeners.get(type) || []).forEach(handler => handler(event));
+        },
+        focus() {},
+        select() {},
+        setSelectionRange() {}
+    };
+}
+
+/**
+ * @param {object} options
+ * @param {boolean} options.clipboardApi  emulate a secure context
+ * @param {boolean} options.execCommandOk whether execCommand('copy') succeeds
+ */
+function makeWindow(options) {
+    const opts = options || {};
+    const body = makeElement('body');
+    const termElement = makeElement('div');
+
+    const state = {
+        clipboardWrites: [],
+        execCommandCopies: [],
+        overlayMessages: [],
+        appendedTextareas: []
+    };
+
+    const doc = {
+        body,
+        activeElement: null,
+        createElement: makeElement,
+        execCommand(command) {
+            if (command !== 'copy') return false;
+            const textarea = body.children.find(child => child.tagName === 'textarea');
+            state.execCommandCopies.push(textarea ? textarea.value : null);
+            return opts.execCommandOk !== false;
+        }
+    };
+
+    const windowListeners = new Map();
+    const win = {
+        document: doc,
+        atob: value => Buffer.from(value, 'base64').toString('binary'),
+        Uint8Array,
+        TextDecoder,
+        setTimeout: (fn, ms) => setTimeout(fn, ms),
+        clearTimeout: id => clearTimeout(id),
+        addEventListener(type, handler) {
+            if (!windowListeners.has(type)) windowListeners.set(type, []);
+            windowListeners.get(type).push(handler);
+        },
+        dispatch(type) {
+            (windowListeners.get(type) || []).forEach(handler => handler({}));
+        },
+        navigator: {}
+    };
+
+    if (opts.clipboardApi) {
+        win.navigator.clipboard = {
+            writeText(text) {
+                state.clipboardWrites.push(text);
+                return opts.clipboardRejects ? Promise.reject(new Error('denied')) : Promise.resolve();
+            }
+        };
+    }
+
+    let selection = '';
+    const selectionHandlers = [];
+    const oscHandlers = new Map();
+
+    // Mirrors xterm.js's IBuffer: `viewportY` is where the visible rows start,
+    // and `isWrapped` marks a row that continues the one above it.
+    const bufferLines = opts.buffer || [];
+    const wrapped = opts.wrapped || [];
+    win.term = {
+        element: termElement,
+        rows: opts.rows || 24,
+        // Wide enough that the plain fixtures above are never "full".
+        cols: opts.cols || 80,
+        getSelection: () => selection,
+        onSelectionChange(handler) { selectionHandlers.push(handler); },
+        buffer: {
+            active: {
+                length: bufferLines.length,
+                viewportY: opts.viewportY || 0,
+                getLine(y) {
+                    if (y < 0 || y >= bufferLines.length) return undefined;
+                    return {
+                        isWrapped: !!wrapped[y],
+                        translateToString: () => bufferLines[y]
+                    };
+                }
+            }
+        },
+        parser: {
+            registerOscHandler(ident, handler) { oscHandlers.set(ident, handler); }
+        }
+    };
+
+    const originalAppend = body.appendChild.bind(body);
+    body.appendChild = child => {
+        if (child.tagName === 'textarea') state.appendedTextareas.push(child);
+        return originalAppend(child);
+    };
+
+    return {
+        win,
+        state,
+        overlayNode: () => termElement.children.find(c => c.className === 'claude-clipboard-overlay'),
+        selectText(text) {
+            selection = text;
+            selectionHandlers.forEach(handler => handler());
+        },
+        osc(ident, data) { return oscHandlers.get(ident)(data); },
+        hasOscHandler: ident => oscHandlers.has(ident),
+        termElement
+    };
+}
+
+// --- Tests ----------------------------------------------------------------
+
+test('secure context: a drag selection is written to the clipboard once', async () => {
+    const env = makeWindow({ clipboardApi: true });
+    bridge.install(env.win);
+
+    env.termElement.dispatch('mousedown');
+    env.selectText('hello');
+    env.selectText('hello world'); // selection grows while dragging
+    assert.deepStrictEqual(env.state.clipboardWrites, [], 'must not copy mid-drag');
+
+    env.win.dispatch('mouseup');
+    await tick();
+
+    assert.deepStrictEqual(env.state.clipboardWrites, ['hello world']);
+    assert.strictEqual(env.overlayNode().textContent, '✂', 'success shows the scissors');
+});
+
+test('insecure context: falls back to a hidden textarea and execCommand', async () => {
+    const env = makeWindow({ clipboardApi: false, execCommandOk: true });
+    bridge.install(env.win);
+
+    env.termElement.dispatch('mousedown');
+    env.selectText('over plain http');
+    env.win.dispatch('mouseup');
+    await tick();
+
+    assert.deepStrictEqual(env.state.execCommandCopies, ['over plain http']);
+    assert.strictEqual(env.state.appendedTextareas.length, 1, 'exactly one temporary textarea');
+    assert.strictEqual(
+        env.win.document.body.children.length, 0,
+        'the temporary textarea must be removed again'
+    );
+    assert.strictEqual(env.overlayNode().textContent, '✂');
+});
+
+test('a failed clipboard write never reports success', async () => {
+    const env = makeWindow({ clipboardApi: false, execCommandOk: false });
+    bridge.install(env.win);
+
+    env.termElement.dispatch('mousedown');
+    env.selectText('blocked');
+    env.win.dispatch('mouseup');
+    await tick();
+
+    const overlay = env.overlayNode();
+    assert.notStrictEqual(overlay.textContent, '✂', 'must not claim it copied');
+    assert.strictEqual(overlay.textContent, '⚠', 'shows a warning instead');
+});
+
+test('a refused copy is reported to the page, not left as a mystery badge', async () => {
+    // An earlier version put a clickable badge over the terminal to supply the
+    // missing gesture. It could not explain itself in situ, so the page is told
+    // instead and points at its own copy button.
+    const refusals = [];
+    const env = makeWindow({ clipboardApi: false, execCommandOk: false });
+    bridge.install(env.win, { onRefused: (text) => refusals.push(text) });
+
+    env.osc(52, Buffer.from('from /copy', 'utf8').toString('base64'));
+    await tick();
+
+    assert.deepStrictEqual(refusals, ['from /copy']);
+    assert.strictEqual(env.overlayNode().textContent, '⚠', 'and never the scissors');
+});
+
+test('the overlay is status only — it must not be clickable', async () => {
+    const env = makeWindow({ clipboardApi: false, execCommandOk: false });
+    bridge.install(env.win);
+
+    env.termElement.dispatch('mousedown');
+    env.selectText('blocked');
+    env.win.dispatch('mouseup');
+    await tick();
+
+    env.state.execCommandCopies.length = 0;
+    env.overlayNode().dispatch('click');
+    assert.deepStrictEqual(
+        env.state.execCommandCopies, [],
+        'a click on the overlay must do nothing at all'
+    );
+});
+
+test('a rejected clipboard API promise still tries the textarea', async () => {
+    const env = makeWindow({ clipboardApi: true, clipboardRejects: true, execCommandOk: true });
+    bridge.install(env.win);
+
+    env.termElement.dispatch('mousedown');
+    env.selectText('unfocused document');
+    env.win.dispatch('mouseup');
+    await tick();
+    await tick();
+
+    assert.deepStrictEqual(env.state.execCommandCopies, ['unfocused document']);
+});
+
+test('OSC 52 is handled and base64 UTF-8 is decoded', async () => {
+    const env = makeWindow({ clipboardApi: true });
+    bridge.install(env.win);
+
+    assert.ok(env.hasOscHandler(52), 'ttyd 1.7.7 registers no OSC 52 handler of its own');
+    const payload = Buffer.from('žltý kôň — ok', 'utf8').toString('base64');
+    assert.strictEqual(env.osc(52, `c;${payload}`), true, 'must swallow the escape sequence');
+    await tick();
+
+    assert.deepStrictEqual(env.state.clipboardWrites, ['žltý kôň — ok']);
+});
+
+test('OSC 52 without a selection parameter still copies', async () => {
+    const env = makeWindow({ clipboardApi: true });
+    bridge.install(env.win);
+
+    env.osc(52, `;${Buffer.from('no Pc', 'utf8').toString('base64')}`);
+    await tick();
+
+    assert.deepStrictEqual(env.state.clipboardWrites, ['no Pc']);
+});
+
+test('an OSC 52 read request is refused, never answered', async () => {
+    const env = makeWindow({ clipboardApi: true });
+    bridge.install(env.win);
+
+    assert.strictEqual(env.osc(52, 'c;?'), true);
+    await tick();
+    assert.deepStrictEqual(env.state.clipboardWrites, []);
+});
+
+test('malformed OSC 52 payloads are swallowed, not printed', async () => {
+    const env = makeWindow({ clipboardApi: true });
+    bridge.install(env.win);
+
+    assert.strictEqual(env.osc(52, 'c;'), true);
+    await tick();
+    assert.deepStrictEqual(env.state.clipboardWrites, []);
+});
+
+test("ttyd's own execCommand('copy') is neutralised while a selection exists", async () => {
+    const env = makeWindow({ clipboardApi: true });
+    bridge.install(env.win);
+
+    // No selection: nothing to hide, let it through.
+    assert.doesNotThrow(() => env.win.document.execCommand('copy'));
+
+    env.selectText('anything');
+    // With a selection, ttyd's call must throw so ttyd returns before showing
+    // its unconditional overlay - the bridge reports the real result instead.
+    assert.throws(() => env.win.document.execCommand('copy'), /clipboard bridge/);
+});
+
+test('installing twice is a no-op', async () => {
+    const env = makeWindow({ clipboardApi: true });
+    assert.ok(bridge.install(env.win), 'first install returns a controller');
+    assert.strictEqual(bridge.install(env.win), false, 'second install does nothing');
+});
+
+// --- Touch devices --------------------------------------------------------
+// xterm.js registers no touch handlers in its selection service, and the
+// canvas renderer leaves no DOM text behind, so a finger can select nothing.
+// Reading the buffer is the only copy path a phone has.
+
+test('reads the visible screen from the buffer, not the whole scrollback', () => {
+    const env = makeWindow({ clipboardApi: true, buffer: ['old 1', 'old 2', 'shown 1', 'shown 2'], rows: 2, viewportY: 2 });
+    const controller = bridge.install(env.win);
+    assert.strictEqual(controller.read('screen'), 'shown 1\nshown 2');
+});
+
+test('reads the full scrollback when asked', () => {
+    const env = makeWindow({ clipboardApi: true, buffer: ['old 1', 'old 2', 'shown 1'], rows: 1, viewportY: 2 });
+    const controller = bridge.install(env.win);
+    assert.strictEqual(controller.read('all'), 'old 1\nold 2\nshown 1');
+});
+
+test('rejoins wrapped lines so a long command is one line again', () => {
+    const env = makeWindow({
+        clipboardApi: true,
+        buffer: ['git commit -m "a very ', 'long message"'],
+        wrapped: [false, true],
+        rows: 2,
+        viewportY: 0
+    });
+    const controller = bridge.install(env.win);
+    assert.strictEqual(controller.read('screen'), 'git commit -m "a very long message"');
+});
+
+// tmux hard-wraps at the pane width and repaints row by row, so isWrapped
+// stays false on every row. Measured: a 46-column pane, a 46-char row.
+test('rejoins tmux hard-wrapped rows, where isWrapped is always false', () => {
+    const env = makeWindow({
+        clipboardApi: true,
+        cols: 10,
+        buffer: ['https://ex', 'ample.com/', 'oauth?a=1'],
+        wrapped: [false, false, false], // tmux never sets this
+        rows: 3,
+        viewportY: 0
+    });
+    const controller = bridge.install(env.win);
+    assert.strictEqual(controller.read('screen'), 'https://example.com/oauth?a=1');
+});
+
+test('a short row ends the line, so the next output is not glued on', () => {
+    const env = makeWindow({
+        clipboardApi: true,
+        cols: 10,
+        buffer: ['https://ex', 'ample.com', 'next'],
+        rows: 3,
+        viewportY: 0
+    });
+    const controller = bridge.install(env.win);
+    assert.strictEqual(controller.read('screen'), 'https://example.com\nnext');
+});
+
+test('a blank row after a full row is a real line break, not a continuation', () => {
+    const env = makeWindow({
+        clipboardApi: true,
+        cols: 10,
+        buffer: ['0123456789', '', 'after'],
+        rows: 3,
+        viewportY: 0
+    });
+    const controller = bridge.install(env.win);
+    assert.strictEqual(controller.read('screen'), '0123456789\n\nafter');
+});
+
+test('rejoining can be turned off when the heuristic is wrong', () => {
+    const env = makeWindow({
+        clipboardApi: true,
+        cols: 10,
+        buffer: ['0123456789', 'separate'],
+        rows: 2,
+        viewportY: 0
+    });
+    const controller = bridge.install(env.win);
+    assert.strictEqual(controller.read('screen', false), '0123456789\nseparate');
+    assert.strictEqual(controller.read('screen', true), '0123456789separate');
+});
+
+test('a copy of a tmux-wrapped URL contains no newline', async () => {
+    const env = makeWindow({
+        clipboardApi: true,
+        cols: 12,
+        buffer: ['https://clau', 'de.com/oauth', '?code=abc'],
+        rows: 3,
+        viewportY: 0
+    });
+    const controller = bridge.install(env.win);
+
+    await controller.copy('screen');
+    assert.deepStrictEqual(env.state.clipboardWrites, ['https://claude.com/oauth?code=abc']);
+    assert.ok(
+        !env.state.clipboardWrites[0].includes('\n'),
+        'a newline inside the URL is what pastes as a stray space'
+    );
+});
+
+test('trailing blank rows are not copied', () => {
+    const env = makeWindow({ clipboardApi: true, buffer: ['output', '', '', ''], rows: 4, viewportY: 0 });
+    const controller = bridge.install(env.win);
+    assert.strictEqual(controller.read('screen'), 'output');
+});
+
+test('a button-driven copy writes the buffer text to the clipboard', async () => {
+    const env = makeWindow({ clipboardApi: true, buffer: ['tap to copy'], rows: 1, viewportY: 0 });
+    const controller = bridge.install(env.win);
+
+    const result = await controller.copy('screen');
+    assert.strictEqual(result.copied, true);
+    assert.deepStrictEqual(env.state.clipboardWrites, ['tap to copy']);
+});
+
+test('a button-driven copy on plain HTTP uses the textarea fallback', async () => {
+    const env = makeWindow({ clipboardApi: false, execCommandOk: true, buffer: ['no https here'], rows: 1, viewportY: 0 });
+    const controller = bridge.install(env.win);
+
+    const result = await controller.copy('screen');
+    assert.strictEqual(result.copied, true, 'the tap is the gesture execCommand needs');
+    assert.deepStrictEqual(env.state.execCommandCopies, ['no https here']);
+});
+
+test('on plain HTTP the fallback runs synchronously, inside the user gesture', () => {
+    // Chrome only allows execCommand('copy') while it is handling a gesture.
+    // If anything awaited before the call, the gesture would be gone and the
+    // copy would be refused in a real browser while still passing the test
+    // above. So assert it happened before control returned to the caller.
+    const env = makeWindow({ clipboardApi: false, execCommandOk: true, buffer: ['sync please'], rows: 1, viewportY: 0 });
+    const controller = bridge.install(env.win);
+
+    controller.copy('screen'); // deliberately not awaited
+    assert.deepStrictEqual(
+        env.state.execCommandCopies, ['sync please'],
+        'the clipboard write must not be deferred to a later task'
+    );
+});
+
+test('a button-driven copy reports failure instead of claiming success', async () => {
+    const env = makeWindow({ clipboardApi: false, execCommandOk: false, buffer: ['blocked'], rows: 1, viewportY: 0 });
+    const controller = bridge.install(env.win);
+
+    const result = await controller.copy('screen');
+    assert.strictEqual(result.copied, false);
+    assert.strictEqual(result.text, 'blocked', 'the caller gets the text so it can offer the OS selection');
+});
+
+test('an empty terminal copies nothing rather than an empty success', async () => {
+    const env = makeWindow({ clipboardApi: true, buffer: ['', ''], rows: 2, viewportY: 0 });
+    const controller = bridge.install(env.win);
+
+    const result = await controller.copy('screen');
+    assert.strictEqual(result.copied, false);
+    assert.deepStrictEqual(env.state.clipboardWrites, []);
+});
+
+test('base64 decoding rejects garbage instead of copying it', () => {
+    const env = makeWindow({ clipboardApi: true });
+    assert.strictEqual(bridge.decodeBase64Utf8(env.win, 'aGk='), 'hi');
+});
+
+// --- Link detection -------------------------------------------------------
+// Terminal text is not markup, so the URL boundaries have to be guessed.
+
+test('finds a plain URL', () => {
+    assert.strictEqual(
+        bridge.findLastUrl('Open https://claude.com/cai/oauth/authorize?code=true to log in'),
+        'https://claude.com/cai/oauth/authorize?code=true'
+    );
+});
+
+// With several links up, the newest wins: terminal output grows downwards, so
+// the last one is what just happened. The header button names the host it
+// copied, which is how you tell on a phone, where there is no hover.
+test('takes the last URL when several are on screen', () => {
+    assert.strictEqual(
+        bridge.findLastUrl('old https://a.example/1\nnew https://b.example/2'),
+        'https://b.example/2'
+    );
+});
+
+test('last wins even with several links on one line', () => {
+    assert.strictEqual(
+        bridge.findLastUrl('docs https://docs.example/x and login https://auth.example/y'),
+        'https://auth.example/y'
+    );
+});
+
+test('a truncated newest link is refused rather than silently taking an older one', () => {
+    // Falling back to the previous link would copy something plausible but
+    // wrong - the user asked for the one that just appeared.
+    assert.deepStrictEqual(
+        bridge.findLastUrl('older https://a.example/ok\nnewer https://b.example/y?code=', true),
+        { url: null, problem: 'truncated' }
+    );
+});
+
+test("box-drawing glyphs from Claude Code's prompt frame are not part of the URL", () => {
+    // Claude Code frames its prompt with │ and friends; with no space before
+    // it, a naive character class swallows the border into the URL.
+    assert.strictEqual(
+        bridge.findLastUrl('│ https://claude.com/cai/oauth?code=x│'),
+        'https://claude.com/cai/oauth?code=x'
+    );
+    assert.strictEqual(
+        bridge.findLastUrl('╭─ https://example.com/a ─╮'),
+        'https://example.com/a'
+    );
+});
+
+test('sentence punctuation after a URL is dropped', () => {
+    assert.strictEqual(bridge.findLastUrl('see https://example.com/a.'), 'https://example.com/a');
+    assert.strictEqual(bridge.findLastUrl('see (https://example.com/a).'), 'https://example.com/a');
+    assert.strictEqual(bridge.findLastUrl('see https://example.com/a,'), 'https://example.com/a');
+});
+
+test('a bracket opened inside the URL is kept', () => {
+    assert.strictEqual(
+        bridge.findLastUrl('https://en.wikipedia.org/wiki/Foo_(bar)'),
+        'https://en.wikipedia.org/wiki/Foo_(bar)'
+    );
+});
+
+test('no URL means no button', () => {
+    assert.strictEqual(bridge.findLastUrl('just some output'), null);
+    assert.strictEqual(bridge.findLastUrl(''), null);
+    assert.strictEqual(bridge.findLastUrl(null), null);
+});
+
+// --- Truncated links -----------------------------------------------------
+// Copying half a URL is worse than copying nothing: the paste fails and
+// nothing on screen says why. Reported after the first fix went live.
+
+test('a link ending in an ellipsis is refused', () => {
+    assert.strictEqual(bridge.findLastUrl('open https://claude.com/cai/oauth?code=abc…'), null);
+    assert.strictEqual(bridge.findLastUrl('open https://claude.com/cai/oauth?code=abc...'), null);
+    // A single full stop is punctuation, not a truncation marker.
+    assert.strictEqual(
+        bridge.findLastUrl('open https://claude.com/cai/oauth?code=abc.'),
+        'https://claude.com/cai/oauth?code=abc'
+    );
+});
+
+test('a link cut inside a percent-escape is refused', () => {
+    assert.strictEqual(bridge.urlProblem('https://x.example/a?s=org%3'), 'truncated');
+    assert.strictEqual(bridge.urlProblem('https://x.example/a?s=org%'), 'truncated');
+});
+
+test('a link cut between query parameters is refused', () => {
+    assert.strictEqual(bridge.urlProblem('https://x.example/a?code=1&'), 'truncated');
+    assert.strictEqual(bridge.urlProblem('https://x.example/a?code='), 'truncated');
+    assert.strictEqual(bridge.urlProblem('https://x.example/a?'), 'truncated');
+});
+
+test('a hostname without a dot is not a link', () => {
+    assert.strictEqual(bridge.urlProblem('https://claude'), 'invalid');
+    assert.strictEqual(bridge.urlProblem('http://localhost'), 'invalid');
+    assert.strictEqual(bridge.urlProblem('https://'), 'invalid');
+});
+
+test('ordinary links pass validation', () => {
+    assert.strictEqual(bridge.urlProblem('https://claude.com/cai/oauth?code=abc'), null);
+    assert.strictEqual(bridge.urlProblem('http://homeassistant.local:8123/'), null);
+    assert.strictEqual(bridge.urlProblem('https://x.example'), null);
+});
+
+test('the problem reason is reported so the UI can explain itself', () => {
+    assert.deepStrictEqual(
+        bridge.findLastUrl('see https://x.example/a?code=', true),
+        { url: null, problem: 'truncated' }
+    );
+    assert.deepStrictEqual(bridge.findLastUrl('nothing here', true), { url: null, problem: 'none' });
+    assert.deepStrictEqual(
+        bridge.findLastUrl('go to https://x.example/ok', true),
+        { url: 'https://x.example/ok', problem: null }
+    );
+});
+
+test('a link running past the bottom of the viewport is completed, not cut', () => {
+    // The viewport shows 2 rows, but the URL wraps onto a third that is
+    // scrolled just below the fold. Reading only the visible screen yields a
+    // truncated "...&code=" - the exact bug reported.
+    const env = makeWindow({
+        clipboardApi: true,
+        cols: 12,
+        buffer: ['https://clau', 'de.com/a?cod', 'e=abcdef'],
+        rows: 2,
+        viewportY: 0
+    });
+    const controller = bridge.install(env.win);
+
+    // The screen text alone yields a URL that looks perfectly valid as a
+    // string - nothing about "...?cod" says it was cut. This is why the check
+    // has to be structural (did it end at a full row at our window's edge?)
+    // rather than a pattern on the text.
+    assert.strictEqual(
+        bridge.findLastUrl(controller.read('screen', true)),
+        'https://claude.com/a?cod',
+        'string-level validation cannot detect this truncation'
+    );
+    assert.strictEqual(controller.findLink().url, 'https://claude.com/a?code=abcdef');
+});
+
+test('a link scrolled off the top is found in the scrollback', () => {
+    const env = makeWindow({
+        clipboardApi: true,
+        cols: 40,
+        buffer: ['https://claude.com/a?code=abcdef', 'later output', 'more output'],
+        rows: 2,
+        viewportY: 1 // the URL row is above the viewport
+    });
+    const controller = bridge.install(env.win);
+
+    assert.strictEqual(bridge.findLastUrl(controller.read('screen', true)), null);
+    assert.strictEqual(controller.findLink().url, 'https://claude.com/a?code=abcdef');
+});
+
+test('a link ending exactly at the column edge, with blank rows after, is complete', () => {
+    // Full row, but a blank one follows - the line really ended at the edge.
+    // Without this any URL that happens to fill the width looks truncated.
+    const env = makeWindow({
+        clipboardApi: true,
+        cols: 24,
+        buffer: ['https://claude.com/a?c=1', '', ''],
+        rows: 3,
+        viewportY: 0
+    });
+    const controller = bridge.install(env.win);
+    assert.strictEqual(controller.findLink().url, 'https://claude.com/a?c=1');
+});
+
+test('with no link anywhere, findLink reports "none" rather than guessing', () => {
+    const env = makeWindow({ clipboardApi: true, buffer: ['just output', 'no links'], rows: 2, viewportY: 0 });
+    const controller = bridge.install(env.win);
+    assert.deepStrictEqual(controller.findLink(), { url: null, problem: 'none' });
+});
+
+test('with only a truncated link, findLink says truncated, not none', () => {
+    const env = makeWindow({
+        clipboardApi: true,
+        cols: 40,
+        buffer: ['see https://claude.com/a?code=…'],
+        rows: 1,
+        viewportY: 0
+    });
+    const controller = bridge.install(env.win);
+    assert.strictEqual(controller.findLink().problem, 'truncated');
+});
+
+// --- Links split across rows ---
+// Fixtures are literal rows captured from a running terminal.
+
+const rows = (list, cols = 46) =>
+    list.map(text => ({ text, full: text.length >= cols, wrapped: false }));
+
+test('a hard-wrapped link is rebuilt without the continuation indent', () => {
+    // Captured live: the row fills all 46 columns and the remainder is
+    // re-indented by 5, so joining the rows verbatim puts spaces inside the URL.
+    const captured = rows([
+        '  ⎿  $ echo "PROBE https://claude.ai/code/arti',
+        '     fact/8f1aa329-c6ce-447f-a58c-bd14ce569558',
+        '     END"'
+    ]);
+    assert.strictEqual(captured[0].full, true, 'fixture must reproduce a full row');
+
+    assert.strictEqual(
+        bridge.findLinkInRows(captured, 46).url,
+        'https://claude.ai/code/artifact/8f1aa329-c6ce-447f-a58c-bd14ce569558'
+    );
+});
+
+test('a trailing word on the last row is not swallowed into the link', () => {
+    // "END" follows a space that the wrap consumed, so the screen cannot prove
+    // it is separate - the rule that a continuation may not start with a letter
+    // unless both rows are full is what keeps it out.
+    const captured = rows([
+        '  ⎿  $ echo "PROBE https://claude.ai/code/arti',
+        '     fact/8f1aa329-c6ce-447f-a58c-bd14ce569558',
+        '     END"'
+    ]);
+    assert.ok(!bridge.findLinkInRows(captured, 46).url.includes('END'));
+});
+
+test('a link whose tail lands on a short indented row is still rebuilt', () => {
+    // Reported live: copied only ".../artifact/8f1". Same row shape as the
+    // ' END"' case above, which must NOT join - told apart by the tail's shape.
+    const narrow = rows([
+        '● https://claude.ai/code/artifact/8f1',
+        '  aa329-c6ce-447f-a58c-bd14ce569558'
+    ], 37);
+    assert.strictEqual(narrow[0].full, true, 'fixture must fill the pane');
+    assert.strictEqual(narrow[1].full, false, 'fixture tail must be short');
+
+    assert.strictEqual(
+        bridge.findLinkInRows(narrow, 37).url,
+        'https://claude.ai/code/artifact/8f1aa329-c6ce-447f-a58c-bd14ce569558'
+    );
+});
+
+test('a continuation that fills the width is joined whatever it looks like', () => {
+    // A row filled to the last column was split mid-token - there was no room
+    // for a space - so the shape of the continuation does not matter. Without
+    // that, a path segment of plain letters would be read as the next word.
+    const wrapped = rows([
+        '● https://example.com/verylong',
+        '  pathsegmentcontinuingfurther',
+        ''
+    ], 30);
+    assert.strictEqual(wrapped[1].full, true, 'fixture continuation must be full');
+
+    assert.strictEqual(
+        bridge.findLinkInRows(wrapped, 30).url,
+        'https://example.com/verylongpathsegmentcontinuingfurther'
+    );
+});
+
+test('a tail of URL punctuation with no digits still counts as a link', () => {
+    const wrapped = rows([
+        '● https://example.com/aaaa/bbb',
+        '  /ccc-ddd',
+        ''
+    ], 30);
+    assert.strictEqual(
+        bridge.findLinkInRows(wrapped, 30).url,
+        'https://example.com/aaaa/bbb/ccc-ddd'
+    );
+});
+
+test('a link soft-broken at a slash is rebuilt', () => {
+    // Claude Code's own renderer breaks a long URL at "/" when the next segment
+    // would not fit. The row is NOT full, so no width-based rule fires - this
+    // is the case that shipped broken and produced ".../artifact".
+    const rendered = rows([
+        '  https://claude.ai/code/artifact',
+        '  /8f1aa329-c6ce-447f-a58c-bd14ce569558'
+    ]);
+    assert.strictEqual(rendered[0].full, false, 'fixture must reproduce a short row');
+
+    assert.strictEqual(
+        bridge.findLinkInRows(rendered, 46).url,
+        'https://claude.ai/code/artifact/8f1aa329-c6ce-447f-a58c-bd14ce569558'
+    );
+});
+
+test('a path on the next line is not glued onto a link that had room to continue', () => {
+    // The chunk would have fitted on the row above, so the break was a choice
+    // and the link really ended. Without this, any line starting with "/" after
+    // a link would be absorbed.
+    const rendered = rows([
+        '  see https://example.com/a',
+        '  /config/foo is a path'
+    ]);
+    assert.strictEqual(bridge.findLinkInRows(rendered, 46).url, 'https://example.com/a');
+});
+
+test('ordinary output after a link is never absorbed', () => {
+    const rendered = rows([
+        '  https://example.com/a',
+        '  next command output'
+    ]);
+    assert.strictEqual(bridge.findLinkInRows(rendered, 46).url, 'https://example.com/a');
+});
+
+test('a link still growing at the last row is reported as truncated', () => {
+    const rendered = rows([
+        'x https://claude.ai/code/artifact/8f1aa329-c6c'
+    ]);
+    const found = bridge.findLinkInRows(rendered, 46);
+    assert.strictEqual(found.atEdge, true, 'the caller must widen instead of copying this');
+});
+
+test('a link that ends before the edge is not reported as truncated', () => {
+    const rendered = rows(['  https://example.com/a', '']);
+    const found = bridge.findLinkInRows(rendered, 46);
+    assert.strictEqual(found.atEdge, false);
+    assert.strictEqual(found.url, 'https://example.com/a');
+});
+
+test('a renderer that wraps one column short of the pane is still followed', () => {
+    // Measured live: at a 46-column pane Claude Code lays a login URL out in
+    // 45-character rows, so a rule keyed on the pane width never fires and the
+    // 🔗 button copied only the first 45 characters.
+    const url = 'https://claude.com/cai/oauth/authorize?code=true&client_id=9d1c250a' +
+        '&scope=org%3Acreate_api_key&code_challenge=hjWXYekQj00Wfyv1dC3CF414TPcRB5EIEB7tUV2Ov-s';
+    const wrapped = [];
+    for (let at = 0; at < url.length; at += 45) wrapped.push(url.slice(at, at + 45));
+    assert.ok(wrapped.length > 2 && wrapped[0].length === 45, 'fixture must wrap at 45');
+
+    const rendered = rows(['  Use the url below to sign in', ''].concat(wrapped, ['', '  Paste code here >']), 46);
+    assert.strictEqual(bridge.findLinkInRows(rendered, 46).url, url);
+});
+
+test('two coincidentally equal short lines are not mistaken for a wrap', () => {
+    // The wrap column has to sit within a couple of columns of the pane width.
+    // Without that, these two would look like a wrapped block and the line
+    // below would be glued onto the link.
+    const rendered = rows([
+        '  https://example.com/aaa',
+        '  plain output line here',
+        '  another output line ok',
+        '  trailing text'
+    ], 46);
+    assert.strictEqual(bridge.findLinkInRows(rendered, 46).url, 'https://example.com/aaa');
+});
+
+test('the newest link wins when rows hold several', () => {
+    const rendered = rows([
+        '  docs https://docs.example/x',
+        '  login https://auth.example/y'
+    ]);
+    assert.strictEqual(bridge.findLinkInRows(rendered, 46).url, 'https://auth.example/y');
+});
+
+test('the link is found across tmux-wrapped rows, not as two halves', () => {
+    const env = makeWindow({
+        clipboardApi: true,
+        cols: 12,
+        buffer: ['Open https:/', '/claude.com/', 'oauth?code=1', ' to log in'],
+        rows: 4,
+        viewportY: 0
+    });
+    const controller = bridge.install(env.win);
+    assert.strictEqual(controller.findLink().url, 'https://claude.com/oauth?code=1');
+});
+
+(async () => {
+    for (const [name, fn] of tests) {
+        try {
+            await fn();
+            console.log(`ok   ${name}`);
+        } catch (err) {
+            failures++;
+            console.error(`FAIL ${name}\n     ${err.message}`);
+        }
+    }
+    if (failures) {
+        console.error(`\n${failures} clipboard bridge test(s) failed`);
+        process.exit(1);
+    }
+    console.log(`\nAll ${tests.length} clipboard bridge tests passed`);
+})();

--- a/tests/test-terminal-clipboard.js
+++ b/tests/test-terminal-clipboard.js
@@ -72,7 +72,9 @@ function makeWindow(options) {
         clipboardWrites: [],
         execCommandCopies: [],
         overlayMessages: [],
-        appendedTextareas: []
+        appendedTextareas: [],
+        fits: 0,
+        scrollsToBottom: 0
     };
 
     const doc = {
@@ -124,12 +126,20 @@ function makeWindow(options) {
     // and `isWrapped` marks a row that continues the one above it.
     const bufferLines = opts.buffer || [];
     const wrapped = opts.wrapped || [];
+    win.matchMedia = query => ({
+        matches: query === '(pointer: coarse)' ? !!opts.touch : !opts.touch
+    });
+
     win.term = {
         element: termElement,
+        textarea: makeElement('textarea'),
         rows: opts.rows || 24,
         // Wide enough that the plain fixtures above are never "full".
         cols: opts.cols || 80,
         getSelection: () => selection,
+        // ttyd adds fit(); xterm.js provides scrollToBottom().
+        fit() { state.fits += 1; },
+        scrollToBottom() { state.scrollsToBottom += 1; },
         onSelectionChange(handler) { selectionHandlers.push(handler); },
         buffer: {
             active: {
@@ -980,6 +990,66 @@ test('touchend releases the gesture', () => {
     env.termElement.dispatch('touchend', {});
     env.termElement.dispatch('touchmove', { touches: [{ clientY: 200, clientX: 5 }] });
     assert.strictEqual(wheels(env).length, before, 'a move after touchend is not a swipe');
+});
+
+// --- Mobile keyboard ------------------------------------------------------
+// Gboard's predictive text drives an IME composing region and xterm.js re-emits
+// a commit it already sent (xtermjs/xterm.js#6060), so a typed phrase lands in
+// the prompt several times over. Nothing outside xterm.js can cancel what it
+// sends, so the keyboard is put in a non-composing mode instead.
+
+test('a touch device gets a keyboard that does not compose', () => {
+    const env = makeWindow({ clipboardApi: true, touch: true });
+    bridge.install(env.win);
+
+    assert.strictEqual(env.win.term.textarea.attributes.inputmode, 'url');
+    assert.strictEqual(env.win.term.textarea.attributes.autocomplete, 'off');
+});
+
+test('a mouse keeps its normal keyboard', () => {
+    const env = makeWindow({ clipboardApi: true, touch: false });
+    bridge.install(env.win);
+
+    assert.strictEqual(env.win.term.textarea.attributes.inputmode, undefined);
+});
+
+test('a terminal with no textarea is left alone', () => {
+    const env = makeWindow({ clipboardApi: true, touch: true });
+    delete env.win.term.textarea;
+    assert.strictEqual(bridge.installMobileInput(env.win, env.win.term), false);
+});
+
+// --- Viewport settling ----------------------------------------------------
+// The on-screen keyboard shrinks the viewport in steps as it animates. Only a
+// refit pushes the new size through to the pty, and that SIGWINCH is what makes
+// a full-screen app redraw with its prompt at the new bottom - which is why the
+// view used to catch up only once a keystroke forced a redraw.
+
+test('settling the viewport refits so the app is told the new size', () => {
+    const env = makeWindow({ clipboardApi: true });
+    const controller = bridge.install(env.win);
+
+    controller.scrollToBottom();
+    assert.strictEqual(env.state.fits, 1, 'a refit is what reaches the pty');
+    assert.strictEqual(env.state.scrollsToBottom, 1);
+});
+
+test('a terminal without ttyd fit() still scrolls', () => {
+    const env = makeWindow({ clipboardApi: true });
+    const controller = bridge.install(env.win);
+    delete env.win.term.fit;
+
+    controller.scrollToBottom();
+    assert.strictEqual(env.state.scrollsToBottom, 1);
+});
+
+test('a throwing fit() does not stop the scroll', () => {
+    const env = makeWindow({ clipboardApi: true });
+    const controller = bridge.install(env.win);
+    env.win.term.fit = () => { throw new Error('mid-teardown'); };
+
+    controller.scrollToBottom();
+    assert.strictEqual(env.state.scrollsToBottom, 1);
 });
 
 (async () => {

--- a/tests/test-terminal-clipboard.js
+++ b/tests/test-terminal-clipboard.js
@@ -143,6 +143,7 @@ function makeWindow(options) {
         onSelectionChange(handler) { selectionHandlers.push(handler); },
         buffer: {
             active: {
+                type: opts.altScreen ? 'alternate' : 'normal',
                 length: bufferLines.length,
                 viewportY: opts.viewportY || 0,
                 getLine(y) {
@@ -864,6 +865,8 @@ test('the link is found across tmux-wrapped rows, not as two halves', () => {
 // all. Measured on the live terminal: alternate_on=1, mouse_any_flag=1.
 // A row is 40/20 = 2px tall in this fixture (element height 40, rows 20).
 
+const SCROLLBACK = Array.from({ length: 40 }, (_, i) => 'line ' + i);
+
 const swipe = (env, from, to, extra) => {
     env.termElement.dispatch('touchstart', { touches: [{ clientY: from, clientX: 5 }] });
     return env.termElement.dispatch('touchmove',
@@ -871,8 +874,29 @@ const swipe = (env, from, to, extra) => {
 };
 const wheels = env => env.termElement.dispatched.filter(e => e.type === 'wheel');
 
+test('a swipe sends nothing when there is no scrollback', () => {
+    // xterm.js turns a wheel event into arrow keys when the buffer has no
+    // scrollback, and sends them as input - under tmux that walks Claude
+    // Code's message history into the prompt, which reads as the terminal
+    // inventing text. The alternate buffer never has scrollback.
+    // A long buffer, so only the alternate-buffer check can reject this.
+    const env = makeWindow({ clipboardApi: true, rows: 20, altScreen: true, buffer: SCROLLBACK });
+    bridge.install(env.win);
+
+    swipe(env, 100, 130);
+    assert.deepStrictEqual(wheels(env), [], 'a swipe must never reach the pty as keystrokes');
+});
+
+test('a swipe sends nothing when the scrollback is shorter than the screen', () => {
+    const env = makeWindow({ clipboardApi: true, rows: 20, buffer: ['only one line'] });
+    bridge.install(env.win);
+
+    swipe(env, 100, 130);
+    assert.deepStrictEqual(wheels(env), []);
+});
+
 test('swiping down scrolls back, one wheel event per row', () => {
-    const env = makeWindow({ clipboardApi: true, rows: 20 });
+    const env = makeWindow({ clipboardApi: true, rows: 20, buffer: SCROLLBACK });
     bridge.install(env.win);
 
     swipe(env, 100, 106); // finger down 6px = 3 rows
@@ -882,7 +906,7 @@ test('swiping down scrolls back, one wheel event per row', () => {
 });
 
 test('swiping up scrolls forward', () => {
-    const env = makeWindow({ clipboardApi: true, rows: 20 });
+    const env = makeWindow({ clipboardApi: true, rows: 20, buffer: SCROLLBACK });
     bridge.install(env.win);
 
     swipe(env, 100, 94);
@@ -890,7 +914,7 @@ test('swiping up scrolls forward', () => {
 });
 
 test('a move shorter than one row scrolls nothing yet', () => {
-    const env = makeWindow({ clipboardApi: true, rows: 20 });
+    const env = makeWindow({ clipboardApi: true, rows: 20, buffer: SCROLLBACK });
     bridge.install(env.win);
 
     swipe(env, 100, 101); // 1px, row is 2px
@@ -898,7 +922,7 @@ test('a move shorter than one row scrolls nothing yet', () => {
 });
 
 test('sub-row moves accumulate instead of being discarded', () => {
-    const env = makeWindow({ clipboardApi: true, rows: 20 });
+    const env = makeWindow({ clipboardApi: true, rows: 20, buffer: SCROLLBACK });
     bridge.install(env.win);
 
     env.termElement.dispatch('touchstart', { touches: [{ clientY: 100, clientX: 5 }] });
@@ -911,7 +935,7 @@ test('sub-row moves accumulate instead of being discarded', () => {
 test('the leftover of a partial row carries into the next move', () => {
     // 3px with a 2px row is one row and 1px over. Dropping that remainder
     // instead of keeping it makes a slow drag lose about half its distance.
-    const env = makeWindow({ clipboardApi: true, rows: 20 });
+    const env = makeWindow({ clipboardApi: true, rows: 20, buffer: SCROLLBACK });
     bridge.install(env.win);
 
     env.termElement.dispatch('touchstart', { touches: [{ clientY: 100, clientX: 5 }] });
@@ -923,7 +947,7 @@ test('the leftover of a partial row carries into the next move', () => {
 
 test('a sub-row move leaves the gesture to the browser', () => {
     // Claiming a move that scrolled nothing would swallow taps and flings.
-    const env = makeWindow({ clipboardApi: true, rows: 20 });
+    const env = makeWindow({ clipboardApi: true, rows: 20, buffer: SCROLLBACK });
     bridge.install(env.win);
 
     env.termElement.dispatch('touchstart', { touches: [{ clientY: 100, clientX: 5 }] });
@@ -933,7 +957,7 @@ test('a sub-row move leaves the gesture to the browser', () => {
 
 test('a second finger mid-gesture stops the scroll', () => {
     // Starting one-fingered and then pinching must not keep scrolling.
-    const env = makeWindow({ clipboardApi: true, rows: 20 });
+    const env = makeWindow({ clipboardApi: true, rows: 20, buffer: SCROLLBACK });
     bridge.install(env.win);
 
     env.termElement.dispatch('touchstart', { touches: [{ clientY: 100, clientX: 5 }] });
@@ -944,7 +968,7 @@ test('a second finger mid-gesture stops the scroll', () => {
 });
 
 test('the gesture is claimed, or the browser would treat it as a page scroll', () => {
-    const env = makeWindow({ clipboardApi: true, rows: 20 });
+    const env = makeWindow({ clipboardApi: true, rows: 20, buffer: SCROLLBACK });
     bridge.install(env.win);
 
     const ev = swipe(env, 100, 106);
@@ -957,7 +981,7 @@ test('the gesture is claimed, or the browser would treat it as a page scroll', (
 
 test('a gesture xterm.js already handled is left alone', () => {
     // xterm.js prevents the default when it scrolled the viewport itself.
-    const env = makeWindow({ clipboardApi: true, rows: 20 });
+    const env = makeWindow({ clipboardApi: true, rows: 20, buffer: SCROLLBACK });
     bridge.install(env.win);
 
     swipe(env, 100, 106, { defaultPrevented: true });
@@ -965,7 +989,7 @@ test('a gesture xterm.js already handled is left alone', () => {
 });
 
 test('two fingers are left to the browser for pinch-zoom', () => {
-    const env = makeWindow({ clipboardApi: true, rows: 20 });
+    const env = makeWindow({ clipboardApi: true, rows: 20, buffer: SCROLLBACK });
     bridge.install(env.win);
 
     env.termElement.dispatch('touchstart', { touches: [{ clientY: 100, clientX: 5 }, { clientY: 200, clientX: 5 }] });
@@ -974,7 +998,7 @@ test('two fingers are left to the browser for pinch-zoom', () => {
 });
 
 test('a fling is capped so one gesture cannot flood the app', () => {
-    const env = makeWindow({ clipboardApi: true, rows: 20 });
+    const env = makeWindow({ clipboardApi: true, rows: 20, buffer: SCROLLBACK });
     bridge.install(env.win);
 
     swipe(env, 500, 900); // 400px = 200 rows
@@ -982,7 +1006,7 @@ test('a fling is capped so one gesture cannot flood the app', () => {
 });
 
 test('touchend releases the gesture', () => {
-    const env = makeWindow({ clipboardApi: true, rows: 20 });
+    const env = makeWindow({ clipboardApi: true, rows: 20, buffer: SCROLLBACK });
     bridge.install(env.win);
 
     swipe(env, 100, 106);


### PR DESCRIPTION
Fixes #30.

## What was wrong

ttyd 1.7.7 — the newest release, and the one the Alpine 3.21 base ships — copies a mouse selection with `document.execCommand('copy')`. xterm.js keeps its selection internally and paints it to a canvas, so there is no DOM selection for that call to copy: it is a no-op. The scissors overlay is shown unconditionally afterwards, which is why the reporter saw "Claude Code do its normal quick copy" with nothing on the clipboard.

`/copy` failed for a separate reason: ttyd 1.7.7 loads no clipboard addon, so the OSC 52 sequence Claude Code emits is discarded. tmux was also dropping it before that — `set-clipboard` defaults to `external`, which ignores what applications in the pane send.

Upgrading ttyd would not have helped. 1.7.7 is the latest release and still has both; the `ClipboardAddon` only appears on `main`.

## Approach

No ttyd fork and no frontend rebuild. ttyd exports its xterm.js instance as `window.term`, and the terminal is already proxied same-origin at `/terminal/`, so the fix is one vanilla-JS file loaded by the page that embeds it.

- **Mouse selection** — read with `terminal.getSelection()`, written with `navigator.clipboard.writeText()`, falling back to a hidden textarea where that API does not exist. The `✂` overlay now appears only when a write actually succeeded.
- **OSC 52** — its own handler on ttyd's terminal, sharing the same writer. Read requests (`\e]52;c;?\a`) are swallowed rather than answered, so a program in the terminal cannot exfiltrate the host clipboard.
- **tmux** — `set -g set-clipboard on`, plus `set -as terminal-features ',*:clipboard'` because tmux otherwise waits for terminfo to advertise `Ms`.

## Touch devices could not copy or scroll at all

Testing this through Home Assistant's mobile app turned up two more problems, both in the same place: xterm.js gives touch far less than it gives a mouse.

**Nothing could be selected.** Its selection service registers no touch handlers, so a finger selects nothing in the terminal. Two header buttons fix that. **📋 Copy** reads the text out of the xterm.js buffer into a textarea, where a long-press gives the native selection handles, with a one-tap *Copy all* and a visible-screen / full-scrollback switch. **🔗 Copy link** appears by itself whenever a link is on screen, which makes getting an OAuth login URL out a single tap.

**Nothing could be scrolled.** `touchstart` and `touchmove` are dropped outright while the application has mouse reporting on:

```js
el.addEventListener('touchstart', ev => {
  if (this.coreMouseService.areMouseEventsActive) return;
```

and touch is never translated into a mouse report either. Claude Code turns reporting on (checked on a running pane: `mouse_any_flag=1`, and `alternate_on=1`, so there is no scrollback to fall back on), so a phone or a touch PC could not move through the history. The wheel has its own code path, which is why a mouse always worked. Swipes are now translated into wheel events and xterm.js encodes them exactly as it would a real wheel. Pinch-zoom and horizontal panning stay with the browser.

## Long links

A link the terminal broke across rows used to be copied as whatever fitted on one row. Rebuilding it needs the row geometry, and three different splits were measured on a running terminal, each leaving a different trace:

| split | trace | why a naive fix misses it |
|---|---|---|
| hard wrap | row filled, remainder re-indented | joining rows verbatim puts the indent inside the URL |
| soft break | Claude Code breaks at a `/` when the next segment won't fit | the row is **not** full, so a width rule never fires |
| narrow layout | output laid out one column short of the pane | a rule keyed on the pane width never fires either |

The wrap column is therefore measured from the rows rather than assumed. A link that is cut off, or still running at the edge of the rows read, is refused rather than copied in half — pasting half a URL fails with nothing on screen saying why.

## The plain-HTTP limit, stated explicitly

Over `http://homeassistant.local:8123` browsers withhold `navigator.clipboard` entirely (secure-context only) and only honour the `execCommand` fallback during a user gesture.

Every button tap is a gesture, so all of the above works. An OSC 52 sequence arriving from the terminal is not, so **`/copy` alone cannot work there** — the add-on says so in words and points at 📋 instead of failing silently. This is the browser's security model, not something the page can work around, and it is written down in `DOCS.md`.

## Tests

`tests/run-tests.sh` now also runs `tests/test-terminal-clipboard.js` — 72 assertions covering both clipboard paths, the insecure-origin fallback (including that it stays synchronous, or the gesture would be lost in a real browser), link detection, the row-rebuilding rules and the touch gesture. The rebuilding fixtures are the literal rows captured from a running terminal. `test-production-run.sh` gained assertions for the tmux settings and the bridge being wired into the page.

Every rule was mutation-tested: breaking it individually turns the suite red. Four of the touch tests exist because the first mutation run passed and showed the assertions were not pinning what they looked like they were.

## Verified live

Running in the add-on on a real Home Assistant instance (HTTPS, ttyd 1.7.7, tmux 3.5a): mouse selection, `📋`, `🔗`, `/copy` and swipe-scrolling all confirmed by hand on desktop and on a phone.
